### PR TITLE
(MODULES-3037) Manage sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,8 @@ junit/
 .vagrant/
 .bundle/
 coverage/
-.idea/
+/.idea/
+/.vscode/
 .metadata
 *.iml
 .*.sw[op]
@@ -35,3 +36,4 @@ test/version_tmp
 tmp
 .idea
 .config
+

--- a/.sync.yml
+++ b/.sync.yml
@@ -29,7 +29,8 @@
     - "spec/reports"
     - "test/version_tmp"
     - "tmp"
-    - ".idea"
+    - "/.idea/"
+    - "/.vscode/"
     - ".config"
 
 Gemfile:

--- a/examples/init.pp
+++ b/examples/init.pp
@@ -1,8 +1,23 @@
-#class rich::packages {
-  $pkg = 'notepadplusplus'
+# The baseline for module testing used by Puppet Labs is that each manifest
+# should have a corresponding test manifest that declares that class or defined
+# type.
+#
+# Tests are then run by using puppet apply --noop (to check for compilation errors
+# and view a log of events) or by fully applying the test in a virtual environment
+# (to compare the resulting system state to the desired state).
+#
+# Learn more about module testing here: http://docs.puppetlabs.com/guides/tests_smoke.html
+#
+# With symlinks on Windows, please run the following command an administrative command prompt (substituting the proper directories):
 
   package { $pkg:
     ensure   => 'latest',
     provider => 'chocolatey',
   }
-#}
+
+#    mklink /D C:\ProgramData\PuppetLabs\puppet\etc\modules\chocolatey C:\code\puppetlabs\puppetlabs-chocolatey
+#    mklink /D C:\ProgramData\PuppetLabs\code\environments\production\modules\chocolatey C:\code\puppetlabs\puppetlabs-chocolatey
+
+chocolateysource { 'local':
+ location => 'c:\packages',
+}

--- a/lib/facter/chocolateyversion.rb
+++ b/lib/facter/chocolateyversion.rb
@@ -1,18 +1,8 @@
+require 'pathname'
+require Pathname.new(__FILE__).dirname + '../' + 'puppet_x/chocolatey/chocolatey_version'
+
 Facter.add('chocolateyversion') do
   setcode do
-    value = nil
-
-    choco_path = "#{Facter.value(:choco_install_path)}\\bin\\choco.exe"
-    if Puppet::Util::Platform.windows? && File.exist?(choco_path)
-      begin
-        old_choco_message = 'Please run chocolatey /? or chocolatey help - chocolatey v'
-        #Facter::Core::Execution.exec is 2.0.1 forward
-        value = Facter::Util::Resolution.exec("#{choco_path} -v").gsub(old_choco_message,'').strip
-      rescue StandardError => e
-        value = '0'
-      end
-    end
-
-    value || '0'
+    PuppetX::Chocolatey::ChocolateyVersion.version
   end
 end

--- a/lib/puppet/provider/chocolateysource/windows.rb
+++ b/lib/puppet/provider/chocolateysource/windows.rb
@@ -1,0 +1,180 @@
+require 'puppet/type'
+require 'pathname'
+require 'rexml/document'
+
+Puppet::Type.type(:chocolateysource).provide(:windows) do
+  confine :operatingsystem => :windows
+  defaultfor :operatingsystem => :windows
+
+  require Pathname.new(__FILE__).dirname + '../../../' + 'puppet_x/chocolatey/chocolatey_common'
+  include PuppetX::Chocolatey::ChocolateyCommon
+
+  MINIMUM_SUPPORTED_CHOCO_VERSION = '0.9.9.0'
+  MINIMUM_SUPPORTED_CHOCO_VERSION_PRIORITY = '0.9.9.9'
+
+  commands :chocolatey => PuppetX::Chocolatey::ChocolateyCommon.chocolatey_command
+
+  def initialize(value={})
+    super(value)
+    @property_flush = {}
+  end
+
+  def properties
+    if @property_hash.empty?
+      @property_hash = query || { :ensure => ( :absent )}
+      @property_hash[:ensure] = :absent if @property_hash.empty?
+    end
+    @property_hash.dup
+  end
+
+  def query
+    self.class.sources.each do |source|
+      return source.properties if @resource[:name][/\A\S*/].downcase == source.name.downcase
+    end
+
+    return {}
+  end
+
+  def self.get_sources
+    PuppetX::Chocolatey::ChocolateyCommon.set_env_chocolateyinstall
+
+    choco_config = PuppetX::Chocolatey::ChocolateyCommon.choco_config_file
+    raise Puppet::ResourceError, "Config file not found for Chocolatey. Please make sure you have Chocolatey installed." if choco_config.nil?
+    raise Puppet::ResourceError, "An install was detected, but was unable to locate config file at #{choco_config}." unless PuppetX::Chocolatey::ChocolateyCommon.file_exists?(choco_config)
+
+    Puppet.debug("Gathering sources from '#{choco_config}'.")
+    config = REXML::Document.new File.new(choco_config, 'r')
+
+    config.elements.to_a( '//source' )
+  end
+
+  def self.get_source(element)
+    source = {}
+    return source if element.nil?
+
+    source[:name] = element.attributes['id'].downcase if element.attributes['id']
+    source[:location] = element.attributes['value'].downcase if element.attributes['value']
+
+    disabled = false
+    disabled = element.attributes['disabled'].downcase == 'true' if element.attributes['disabled']
+    source[:ensure] = :present
+    source[:ensure] = :disabled if disabled
+
+    source[:priority] = 0
+    source[:priority] = element.attributes['priority'].downcase if element.attributes['priority']
+
+    source[:user] = element.attributes['user'].downcase if element.attributes['user']
+
+    Puppet.debug("Loaded source '#{source.inspect}'.")
+
+    source
+  end
+
+  def self.sources
+    @sources ||=  get_sources.collect do |item|
+      source = get_source(item)
+      new(source)
+    end
+  end
+
+  def self.refresh_sources
+    @sources = nil
+    self.sources
+  end
+
+  def self.instances
+    sources
+  end
+
+  def self.prefetch(resources)
+    instances.each do |provider|
+      if (resource = resources[provider.name])
+        resource.provider = provider
+      end
+    end
+  end
+
+  def create
+    @property_flush[:ensure] = :present
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+  def disable
+    @property_flush[:ensure] = :disabled
+  end
+
+  def destroy
+    @property_flush[:ensure] = :absent
+  end
+
+  def validate
+    choco_version = Gem::Version.new(PuppetX::Chocolatey::ChocolateyCommon.choco_version)
+    if choco_version < Gem::Version.new(MINIMUM_SUPPORTED_CHOCO_VERSION)
+      raise Puppet::ResourceError, "Chocolatey version must be '#{MINIMUM_SUPPORTED_CHOCO_VERSION}' to manage configuration values with Puppet. Detected '#{choco_version}' as your version. Please upgrade Chocolatey to use this resource."
+    end
+
+    if choco_version < Gem::Version.new(MINIMUM_SUPPORTED_CHOCO_VERSION_PRIORITY) && resource[:priority] && resource[:priority] != 0
+      Puppet.warning("Chocolatey is unable to manage priority for sources when version is less than #{MINIMUM_SUPPORTED_CHOCO_VERSION_PRIORITY}. The value you set will be ignored.")
+    end
+
+    if resource[:password] && resource[:password] != ''
+      Puppet.debug("The password is not ensurable, so Puppet is unable to change the value using chocolateysource resource. As a workaround, a password change can be in the form of an exec. Reference Chocolateysource[#{resource[:name]}]")
+    end
+  end
+
+  mk_resource_methods
+
+  def flush
+    args = []
+    args << 'source'
+
+    command = 'add'
+    command = 'remove' if @property_flush[:ensure] == :absent
+
+    args << command
+    args << '--name' << resource[:name]
+
+    if @property_flush[:ensure] != :absent
+      args << '--source' << resource[:location]
+
+      choco_gem_version = Gem::Version.new(PuppetX::Chocolatey::ChocolateyCommon.choco_version)
+
+      if resource[:user]  && resource[:user] != ''
+        args << '--user' << resource[:user]
+        args << '--password' << resource[:password]
+      end
+
+      if choco_gem_version >= Gem::Version.new(MINIMUM_SUPPORTED_CHOCO_VERSION_PRIORITY)
+        args << '--priority' << (resource[:priority] || 0)
+      end
+    end
+
+    begin
+      Puppet::Util::Execution.execute([command(:chocolatey), *args])
+    rescue Puppet::ExecutionFailure
+      raise Puppet::Error, "An error occurred running choco. Unable to set Chocolatey source configuration for #{self.inspect}"
+    end
+
+    if @property_flush[:ensure] != :absent
+      command = 'enable'
+      command = 'disable' if @property_flush[:ensure] == :disabled
+      begin
+        Puppet::Util::Execution.execute([command(:chocolatey), 'source', command, '--name', resource[:name]])
+      rescue Puppet::ExecutionFailure
+        raise Puppet::Error, "An error occurred running choco. Unable to set Chocolatey source configuration for #{self.inspect}"
+      end
+    end
+
+    @property_hash.clear
+    @property_hash = { :ensure => ( @property_flush[:ensure] )}  #if  @property_flush[:ensure] == :absent
+
+    @property_flush.clear
+
+    self.class.refresh_sources
+    @property_hash = query
+  end
+
+end

--- a/lib/puppet/provider/package/chocolatey.rb
+++ b/lib/puppet/provider/package/chocolatey.rb
@@ -30,84 +30,33 @@ Puppet::Type.type(:package).provide(:chocolatey, :parent => Puppet::Provider::Pa
   has_feature :holdable
   #has_feature :package_settings
 
+  require Pathname.new(__FILE__).dirname + '../../../' + 'puppet_x/chocolatey/chocolatey_common'
+  include PuppetX::Chocolatey::ChocolateyCommon
+
+  commands :chocolatey => PuppetX::Chocolatey::ChocolateyCommon.chocolatey_command
+
   def initialize(value={})
     super(value)
-    @compiled_choco = nil
   end
-
-  def self.file_exists?(path)
-    File.exist?(path)
-  end
-
-  def self.chocolatey_command
-    if Puppet::Util::Platform.windows?
-      #default_location = $::choco_installpath || ENV['ALLUSERSPROFILE'] + '\chocolatey'
-      chocopath = ('C:\ProgramData\chocolatey' if file_exists?('C:\ProgramData\chocolatey\bin\choco.exe')) ||
-          (ENV['ChocolateyInstall'] if ENV['ChocolateyInstall'] && file_exists?("#{ENV['ChocolateyInstall']}\\bin\\choco.exe")) ||
-          ('C:\Chocolatey' if file_exists?('C:\Chocolatey\bin\choco.exe')) ||
-          "#{ENV['ALLUSERSPROFILE']}\\chocolatey"
-
-      chocopath += '\bin\choco.exe'
-    else
-      chocopath = 'choco.exe'
-    end
-
-    chocopath
-  end
-
-  def self.compiled_choco=(value)
-    @compiled_choco = value
-  end
-
-  # this ultimately determines if we are on the C# version of choco
-  # so commands can be adjusted accordingly
-  def self.choco_exe?
-    # call `choco -v` one time here and cache the result
-    # - new choco will output a single value e.g. `0.9.9`
-    # - old choco is going to return the default output e.g. `Please run chocolatey /?`
-    if @compiled_choco.nil?
-      execpipe(choco_ver_cmd) do |process|
-        process.each_line do |line|
-          line.chomp!
-          if line.empty?; next; end
-          if line.match(/Please run chocolatey.*/)
-            @compiled_choco = false
-          else
-            @compiled_choco = true
-          end
-        end
-      end
-    end
-
-    @compiled_choco
-  end
-
-  def self.choco_ver_cmd
-    args = []
-    args << '-v'
-
-    [command(:chocolatey), *args]
-  end
-
-  def self.set_env_chocolateyinstall
-    ENV['ChocolateyInstall'] = PuppetX::Chocolatey::ChocolateyInstall.install_path
-  end
-
-  def choco_exe?
-    self.class.choco_exe?
-  end
-
-  commands :chocolatey => chocolatey_command
 
   def print()
     notice("The value is: '${name}'")
   end
 
+  def self.is_compiled_choco?
+    Gem::Version.new(PuppetX::Chocolatey::ChocolateyCommon.choco_version) >= Gem::Version.new(PuppetX::Chocolatey::ChocolateyCommon::FIRST_COMPILED_CHOCO_VERSION)
+  end
+
+  def is_compiled_choco?
+    self.class.is_compiled_choco?
+  end
+
   def install
-    self.class.set_env_chocolateyinstall
+    PuppetX::Chocolatey::ChocolateyCommon.set_env_chocolateyinstall
+     choco_exe = is_compiled_choco?
 
     # always unhold on install
-    unhold if choco_exe?
+    unhold if choco_exe
 
     args = []
 
@@ -121,7 +70,7 @@ Puppet::Type.type(:package).provide(:chocolatey, :parent => Puppet::Provider::Pa
       args << @resource[:name][/\A\S*/]
     else
       args.clear
-      if choco_exe?
+      if choco_exe
         args << 'upgrade'
       else
         args << 'update'
@@ -131,7 +80,7 @@ Puppet::Type.type(:package).provide(:chocolatey, :parent => Puppet::Provider::Pa
       args << @resource[:name][/\A\S*/] << '-version' << @resource[:ensure]
     end
 
-    if choco_exe?
+    if choco_exe
       args << '-dvy'
     end
 
@@ -145,20 +94,21 @@ Puppet::Type.type(:package).provide(:chocolatey, :parent => Puppet::Provider::Pa
   end
 
   def uninstall
-    self.class.set_env_chocolateyinstall
+    PuppetX::Chocolatey::ChocolateyCommon.set_env_chocolateyinstall
+    choco_exe = is_compiled_choco?
 
     # always unhold on uninstall
-    unhold if choco_exe?
+    unhold if choco_exe
 
     args = 'uninstall', @resource[:name][/\A\S*/]
 
-    if choco_exe?
+    if choco_exe
       args << '-dvfy'
     end
 
     args << @resource[:uninstall_options]
 
-    unless choco_exe?
+    unless choco_exe
       if @resource[:source]
         args << '-source' << @resource[:source]
       end
@@ -168,12 +118,13 @@ Puppet::Type.type(:package).provide(:chocolatey, :parent => Puppet::Provider::Pa
   end
 
   def update
-    self.class.set_env_chocolateyinstall
+    PuppetX::Chocolatey::ChocolateyCommon.set_env_chocolateyinstall
+    choco_exe = is_compiled_choco?
 
     # always unhold on upgrade
-    unhold if choco_exe?
+    unhold if choco_exe
 
-    if choco_exe?
+    if choco_exe
       args = 'upgrade', @resource[:name][/\A\S*/], '-dvy'
     else
       args = 'update', @resource[:name][/\A\S*/]
@@ -211,7 +162,7 @@ Puppet::Type.type(:package).provide(:chocolatey, :parent => Puppet::Provider::Pa
     args = []
     args << 'list'
     args << '-lo'
-    if choco_exe?
+    if is_compiled_choco?
       args << '-r'
     end
 
@@ -220,12 +171,13 @@ Puppet::Type.type(:package).provide(:chocolatey, :parent => Puppet::Provider::Pa
 
   def self.instances
     packages = []
-    set_env_chocolateyinstall
+    PuppetX::Chocolatey::ChocolateyCommon.set_env_chocolateyinstall
+    choco_exe = is_compiled_choco?
     begin
       pins = []
-      pin_output = nil unless choco_exe?
+      pin_output = nil unless choco_exe
       #don't add -r yet, as there is an issue in 0.9.9.9/0.9.9.10 that returns full list plus pins
-      pin_output = Puppet::Util::Execution.execute([command(:chocolatey), 'pin', 'list']) if choco_exe?
+      pin_output = Puppet::Util::Execution.execute([command(:chocolatey), 'pin', 'list']) if choco_exe
       unless pin_output.nil?
         pin_output.split("\n").each { |pin| pins << pin.split('|')[0] }
       end
@@ -234,7 +186,7 @@ Puppet::Type.type(:package).provide(:chocolatey, :parent => Puppet::Provider::Pa
         process.each_line do |line|
           line.chomp!
           if line.empty? or line.match(/Reading environment variables.*/); next; end
-          if choco_exe?
+          if choco_exe
             values = line.split('|')
           else
             values = line.split(' ')
@@ -251,7 +203,8 @@ Puppet::Type.type(:package).provide(:chocolatey, :parent => Puppet::Provider::Pa
   end
 
   def latestcmd
-    if choco_exe?
+    choco_exe = is_compiled_choco?
+    if choco_exe
       args = 'upgrade', '--noop', @resource[:name][/\A\S*/], '-r'
     else
       args = 'version', @resource[:name][/\A\S*/]
@@ -261,7 +214,7 @@ Puppet::Type.type(:package).provide(:chocolatey, :parent => Puppet::Provider::Pa
       args << '-source' << @resource[:source]
     end
 
-    unless choco_exe?
+    unless choco_exe
       args << '| findstr /R "latest" | findstr /V "latestCompare"'
     end
 
@@ -270,13 +223,13 @@ Puppet::Type.type(:package).provide(:chocolatey, :parent => Puppet::Provider::Pa
 
   def latest
     package_ver = ''
-    self.class.set_env_chocolateyinstall
+    PuppetX::Chocolatey::ChocolateyCommon.set_env_chocolateyinstall
     begin
       execpipe(latestcmd) do |process|
         process.each_line do |line|
           line.chomp!
           if line.empty?; next; end
-          if choco_exe?
+          if is_compiled_choco?
             values = line.split('|')
             package_ver = values[2]
           else
@@ -294,7 +247,7 @@ Puppet::Type.type(:package).provide(:chocolatey, :parent => Puppet::Provider::Pa
   end
 
   def hold
-    raise ArgumentError, 'Only choco v0.9.9+ can use ensure => held' unless choco_exe?
+    raise ArgumentError, 'Only choco v0.9.9+ can use ensure => held' unless is_compiled_choco?
 
     install
 
@@ -304,7 +257,7 @@ Puppet::Type.type(:package).provide(:chocolatey, :parent => Puppet::Provider::Pa
   end
 
   def unhold
-    return unless choco_exe?
+    return unless is_compiled_choco?
 
     Puppet::Util::Execution.execute([command(:chocolatey), 'pin','remove', '-n', @resource[:name][/\A\S*/]], :failonfail => false)
   end

--- a/lib/puppet/type/chocolateysource.rb
+++ b/lib/puppet/type/chocolateysource.rb
@@ -1,0 +1,146 @@
+require 'puppet/type'
+require 'pathname'
+
+Puppet::Type.newtype(:chocolateysource) do
+
+  @doc = <<-'EOT'
+    Allows managing sources for Chocolatey. A source can be a
+    folder, a CIFS share, a NuGet Http OData feed, or a full
+    Package Gallery. Learn more about sources at
+    https://github.com/chocolatey/choco/wiki/How-To-Host-Feed
+
+  EOT
+
+  def initialize(*args)
+    super
+
+    # if location is unset, use the title
+    if self[:location].nil? then
+      self[:location] = self[:name]
+    end
+  end
+
+  ensurable do
+    newvalue(:present)  { provider.create }
+    newvalue(:disabled) { provider.disable }
+    newvalue(:absent)   { provider.destroy }
+    defaultto :present
+
+    def retrieve
+      provider.properties[:ensure]
+    end
+
+  end
+
+  newparam(:name) do
+    desc "The name of the source. Used for uniqueness. Will set
+      the location to this value if location is unset."
+
+    validate do |value|
+      if value.nil? or value.empty?
+        raise ArgumentError, "A non-empty name must be specified."
+      end
+    end
+
+    isnamevar
+
+    munge do |value|
+      value.downcase
+    end
+
+    def insync?(is)
+      is.downcase == should.downcase
+    end
+  end
+
+  newproperty(:location) do
+    desc "The location of the source repository. Can be a url pointing to
+      an OData feed (like chocolatey/chocolatey_server), a CIFS (UNC) share,
+      or a local folder.
+      The default is the name of the resource"
+
+    validate do |value|
+      if value.nil? or value.empty?
+        raise ArgumentError, "A non-empty location must be specified."
+      end
+    end
+
+    def insync?(is)
+      is.downcase == should.downcase
+    end
+  end
+
+  newproperty(:user) do
+    desc "Optional user name for authenticated feeds.
+      Requires at least Chocolatey v0.9.9.0.
+      Defaults to `nil`. Specifying an empty value is the
+      same as setting the value to nil or not specifying
+      the property at all."
+
+    defaultto ''
+  end
+
+  newparam(:password) do
+    desc "Optional user password for authenticated feeds.
+      Not ensurable. Value is not able to be checked
+      with current value. If you need to update the password,
+      update another setting as well.
+      Requires at least Chocolatey v0.9.9.0.
+      Defaults to `nil`. Specifying an empty value is the
+      same as setting the value to nil or not specifying
+      the property at all."
+
+    defaultto ''
+  end
+
+  newproperty(:priority) do
+    desc "Optional priority for explicit feed order when
+      searching for packages across multiple feeds.
+      The lower the number the higher the priority.
+      Sources with a 0 priority are considered no priority
+      and are added after other sources with a priority
+      number.
+      Requires at least Chocolatey v0.9.9.9.
+      Defaults to 0."
+
+    validate do |value|
+      if value.nil?
+        raise ArgumentError, "A non-empty priority must be specified."
+      end
+      raise ArgumentError, "An integer is necessary for priority. Specify 0 or remove for no priority." unless resource.is_numeric?(value)
+    end
+    defaultto(0)
+  end
+
+  validate do
+    if (!self[:user].nil? && self[:user] != '' && (self[:password].nil? || self[:password] == '')) || ((self[:user].nil? || self[:user] == '') && !self[:password].nil? && self[:password] != '')
+      raise ArgumentError, "If specifying user/password, you must specify both values."
+    end
+
+    if provider.respond_to?(:validate)
+      provider.validate
+    end
+  end
+
+  autorequire(:exec) do
+    ['install_chocolatey_official']
+  end
+
+  def munge_boolean(value)
+    case value
+      when true, "true", :true
+        :true
+      when false, "false", :false
+        :false
+      else
+        fail("munge_boolean only takes booleans")
+    end
+  end
+
+  def is_numeric?(value)
+    # this is what stdlib does. Not sure if we want to emulate or not.
+    #numeric = %r{^-?(?:(?:[1-9]\d*)|0)$}
+    #if value.is_a? Integer or (value.is_a? String and value.match numeric)
+    Float(value) != nil rescue false
+  end
+end

--- a/lib/puppet_x/chocolatey/chocolatey_common.rb
+++ b/lib/puppet_x/chocolatey/chocolatey_common.rb
@@ -1,0 +1,84 @@
+require 'pathname'
+require Pathname.new(__FILE__).dirname + 'chocolatey_version'
+require Pathname.new(__FILE__).dirname + 'chocolatey_install'
+
+module PuppetX
+  module Chocolatey
+    module ChocolateyCommon
+
+      ## determines if C# version of choco
+      FIRST_COMPILED_CHOCO_VERSION = '0.9.9.0'
+
+      def file_exists?(path)
+        File.exist?(path)
+      end
+      module_function :file_exists?
+
+      def chocolatey_command
+        if Puppet::Util::Platform.windows?
+          # When attempting to find the choco command executable, the following
+          # paths are checked:
+          # - Start with the install_path. If choco is found with environment
+          #   variables through the registry or a check on the
+          #   ChocolateyInstall env var (first install of Choco may only have
+          #   this), then use that path.
+          # - Next look to the most commonly used install location (ProgramData)
+          # - Fall back to the older install location for older installations
+          # - If all else fails, attempt to find Chocolatey in the default place
+          #   it installs
+          chocoInstallPath = PuppetX::Chocolatey::ChocolateyInstall.install_path
+
+          chocopath =  (chocoInstallPath if (chocoInstallPath && file_exists?("#{chocoInstallPath}\\bin\\choco.exe"))) ||
+              ('C:\ProgramData\chocolatey' if file_exists?('C:\ProgramData\chocolatey\bin\choco.exe')) ||
+              ('C:\Chocolatey' if file_exists?('C:\Chocolatey\bin\choco.exe')) ||
+              "#{ENV['ALLUSERSPROFILE']}\\chocolatey"
+
+          chocopath += '\bin\choco.exe'
+        else
+          chocopath = 'choco.exe'
+        end
+
+        chocopath
+      end
+      module_function :chocolatey_command
+
+      def set_env_chocolateyinstall
+        ENV['ChocolateyInstall'] = PuppetX::Chocolatey::ChocolateyInstall.install_path
+      end
+      module_function :set_env_chocolateyinstall
+
+      def choco_version
+        @chocoversion ||= self.strip_beta_from_version(PuppetX::Chocolatey::ChocolateyVersion.version)
+      end
+      module_function :choco_version
+
+      def self.strip_beta_from_version(value)
+        return nil if value.nil?
+
+        value.split(/-/)[0]
+      end
+
+      def choco_config_file
+        chocoInstallPath = PuppetX::Chocolatey::ChocolateyInstall.install_path
+        choco_config = "#{chocoInstallPath}\\config\\chocolatey.config"
+
+        return choco_config if file_exists?(choco_config)
+
+        old_choco_config = "#{chocoInstallPath}\\chocolateyinstall\\chocolatey.config"
+
+        return old_choco_config if file_exists?(old_choco_config)
+
+        return nil
+      end
+      module_function :choco_config_file
+
+      # clears the cached values
+      def clear_cached_values
+        @chocoversion = nil
+        @compiled_choco = nil
+      end
+      module_function :clear_cached_values
+
+    end
+  end
+end

--- a/lib/puppet_x/chocolatey/chocolatey_install.rb
+++ b/lib/puppet_x/chocolatey/chocolatey_install.rb
@@ -4,22 +4,21 @@ module PuppetX
 
       def self.install_path
         if Puppet::Util::Platform.windows?
-        require 'win32/registry'
+          require 'win32/registry'
 
-        value = nil
-        begin
-          hive = Win32::Registry::HKEY_LOCAL_MACHINE
-          hive.open('SYSTEM\CurrentControlSet\Control\Session Manager\Environment', Win32::Registry::KEY_READ | 0x100) do |reg|
-            value = reg['ChocolateyInstall']
-          end
-        rescue Win32::Registry::Error => e
           value = nil
+          begin
+            hive = Win32::Registry::HKEY_LOCAL_MACHINE
+            hive.open('SYSTEM\CurrentControlSet\Control\Session Manager\Environment', Win32::Registry::KEY_READ | 0x100) do |reg|
+              value = reg['ChocolateyInstall']
+            end
+          rescue Win32::Registry::Error => e
+            value = nil
+          end
         end
-      end
 
-      value || 'C:\ProgramData\chocolatey'
+        value || 'C:\ProgramData\chocolatey'
       end
-
     end
   end
 end

--- a/lib/puppet_x/chocolatey/chocolatey_install.rb
+++ b/lib/puppet_x/chocolatey/chocolatey_install.rb
@@ -3,10 +3,11 @@ module PuppetX
     class ChocolateyInstall
 
       def self.install_path
+        value = nil
+
         if Puppet::Util::Platform.windows?
           require 'win32/registry'
 
-          value = nil
           begin
             hive = Win32::Registry::HKEY_LOCAL_MACHINE
             hive.open('SYSTEM\CurrentControlSet\Control\Session Manager\Environment', Win32::Registry::KEY_READ | 0x100) do |reg|
@@ -17,7 +18,16 @@ module PuppetX
           end
         end
 
-        value || 'C:\ProgramData\chocolatey'
+        # If machine level is not set, use process or user as the intended
+        # location where Chocolatey would be installed.
+        # Since it is technically possible that Chocolatey could exist on
+        # non-Windows installations, we don't want to confine this
+        # to just Windows.
+        if value.nil?
+          value = ENV['ChocolateyInstall']
+        end
+
+        value
       end
     end
   end

--- a/lib/puppet_x/chocolatey/chocolatey_version.rb
+++ b/lib/puppet_x/chocolatey/chocolatey_version.rb
@@ -1,0 +1,35 @@
+require 'pathname'
+require Pathname.new(__FILE__).dirname + 'chocolatey_install'
+
+module PuppetX
+  module Chocolatey
+    class ChocolateyVersion
+
+      UPGRADE_WARNING = "!!ATTENTION!!
+The next version of Chocolatey (v0.9.9) will require -y to perform
+  behaviors that change state without prompting for confirmation. Start
+  using it now in your automated scripts.
+
+  For details on the all new Chocolatey, visit http://bit.ly/new_choco
+"
+      OLD_CHOCO_MESSAGE = "Please run chocolatey /? or chocolatey help - chocolatey v"
+
+      def self.version
+        version = nil
+        choco_path = "#{PuppetX::Chocolatey::ChocolateyInstall.install_path}\\bin\\choco.exe"
+        if Puppet::Util::Platform.windows? && File.exist?(choco_path)
+          begin
+            # call `choco -v`
+            # - new choco will output a single value e.g. `0.9.9`
+            # - old choco is going to return the default output e.g. `Please run chocolatey /?`
+            version = Puppet::Util::Execution.execute("#{choco_path} -v").gsub(UPGRADE_WARNING,'').gsub(OLD_CHOCO_MESSAGE,'').strip
+          rescue StandardError => e
+            version = '0'
+          end
+        end
+
+        version
+      end
+    end
+  end
+end

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -26,3 +26,4 @@ class chocolatey::config {
 # lint:endignore
   }
 }
+ 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,6 +31,12 @@ RSpec.configure do |c|
   # set the environment variable before files are loaded, otherwise it is too late
   ENV['ChocolateyInstall'] = 'c:\blah'
 
+  begin
+    Win32::Registry.any_instance.stubs(:[]).with('ChocolateyInstall').raises(Win32::Registry::Error.new(2), 'file not found yo')
+  rescue
+    # we don't care
+  end
+
   # https://www.relishapp.com/rspec/rspec-core/v/2-12/docs/mock-framework-integration/mock-with-mocha!
   c.mock_framework = :mocha
   # see output for all failures

--- a/spec/unit/facter/choco_install_path_spec.rb
+++ b/spec/unit/facter/choco_install_path_spec.rb
@@ -1,28 +1,20 @@
+require 'spec_helper'
 require 'facter'
+require 'puppet_x/chocolatey/chocolatey_install'
 
 describe 'choco_install_path fact' do
   subject(:fact) { Facter.fact(:choco_install_path) }
 
-  context 'on Windows', :if => Puppet::Util::Platform.windows? do
-    it "should return install path from registry if it exists" do
-      expected_value = 'C:\somewhere'
-      Win32::Registry.any_instance.expects(:[]).with('ChocolateyInstall').returns(expected_value)
-
-      subject.value.must == expected_value
-    end
-
-    it "should return the default install path if environment variable does not exist" do
-      expected_value = 'C:\ProgramData\chocolatey'
-      Win32::Registry.any_instance.expects(:[]).with('ChocolateyInstall').raises(Win32::Registry::Error.new(2), 'file not found yo')
-
-      subject.value.must == expected_value
-    end
+  before :each do
+    Facter.clear
+    Facter.clear_messages
   end
 
-  context 'on Linux', :if => Puppet.features.posix? do
-    it "should return the default install path on a non-windows system" do
-      subject.value.must == 'C:\ProgramData\chocolatey'
-    end
+  it "should return the output of PuppetX::Chocolatey::ChocolateyInstall.install_path" do
+    expected_value = 'C:\somewhere'
+    PuppetX::Chocolatey::ChocolateyInstall.expects(:install_path).returns(expected_value)
+
+    subject.value.must == expected_value
   end
 
   after :each do

--- a/spec/unit/facter/chocolateyversion_spec.rb
+++ b/spec/unit/facter/chocolateyversion_spec.rb
@@ -1,35 +1,20 @@
+require 'spec_helper'
 require 'facter'
+require 'puppet_x/chocolatey/chocolatey_version'
 
 describe 'chocolateyversion fact' do
   subject(:fact) { Facter.fact(:chocolateyversion) }
 
-  context 'on Windows', :if => Puppet::Util::Platform.windows? do
-    it "should return the value from running choco -v" do
-      expected_value = '1.2.3'
-      Facter::Util::Resolution.expects(:exec).returns(expected_value)
-
-      subject.value.must == expected_value
-    end
-
-    it "should handle cleaning up spaces" do
-      expected_value = '1.2.3'
-      Facter::Util::Resolution.expects(:exec).returns(' ' + expected_value + ' ')
-
-      subject.value.must == expected_value
-    end
-
-    it "should handle older versions of choco" do
-      expected_value = '1.2.3'
-      Facter::Util::Resolution.expects(:exec).returns('Please run chocolatey /? or chocolatey help - chocolatey v' + expected_value)
-
-      subject.value.must == expected_value
-    end
+  before :each do
+    Facter.clear
+    Facter.clear_messages
   end
 
-  context 'on Linux', :if => Puppet.features.posix? do
-    it "should return 0  on a non-windows system" do
-      subject.value.must == "0"
-    end
+  it "should return the output of PuppetX::Chocolatey::ChocolateyVersion.version" do
+    expected_value = '1.2.3'
+    PuppetX::Chocolatey::ChocolateyVersion.expects(:version).returns(expected_value)
+
+    subject.value.must == expected_value
   end
 
   after :each do

--- a/spec/unit/puppet/provider/chocolateysource/windows_spec.rb
+++ b/spec/unit/puppet/provider/chocolateysource/windows_spec.rb
@@ -1,0 +1,589 @@
+require 'spec_helper'
+require 'stringio'
+require 'puppet/type/chocolateysource'
+require 'puppet/provider/chocolateysource/windows'
+require 'rexml/document'
+
+provider = Puppet::Type.type(:chocolateysource).provider(:windows)
+describe provider do
+  let (:name) { 'sourcename' }
+  let (:resource) { Puppet::Type.type(:chocolateysource).new(:provider => :windows, :name => name) }
+  let (:choco_config) { 'c:\choco.config' }
+  let (:choco_config_contents) { <<-'EOT'
+<?xml version="1.0" encoding="utf-8"?>
+<chocolatey xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <config>
+    <add key="cacheLocation" value="" description="Cache location if not TEMP folder." />
+    <add key="commandExecutionTimeoutSeconds" value="2700" description="Default timeout for command execution." />
+    <add key="containsLegacyPackageInstalls" value="true" description="Install has packages installed prior to 0.9.9 series." />
+    <add key="proxy" value="" description="Explicit proxy location." />
+    <add key="proxyUser" value="" description="Optional proxy user." />
+    <add key="proxyPassword" value="" description="Optional proxy password. Encrypted." />
+    <add key="virusCheckMinimumPositives" value="5" description="Minimum numer of scan result positives before flagging a binary as a possible virus. Available in 0.9.10+. Licensed versions only." />
+    <add key="virusScannerType" value="VirusTotal" description="Virus Scanner Type (Generic or VirusTotal). Defaults to VirusTotal for Pro. Available in 0.9.10+. Licensed versions only." />
+    <add key="genericVirusScannerPath" value="" description="The full path to the command line virus scanner executable. Used when virusScannerType is Generic. Available in 0.9.10+. Licensed versions only." />
+    <add key="genericVirusScannerArgs" value="[[File]]" description="The arguments to pass to the generic virus scanner. Use [[File]] for the file path placeholder. Used when virusScannerType is Generic. Available in 0.9.10+. Licensed versions only." />
+    <add key="genericVirusScannerValidExitCodes" value="0" description="The exit codes for the generic virus scanner when a file is not flagged. Separate with comma, defaults to 0. Used when virusScannerType is Generic. Available in 0.9.10+. Licensed versions only." />
+  </config>
+  <sources>
+    <source id="local" value="c:\packages" disabled="true" user="rob" password="bogus/encrypted+value=" priority="0" />
+    <source id="chocolatey" value="https://chocolatey.org/api/v2/" disabled="false" priority="0" />
+    <source id="chocolatey.licensed" value="https://licensedpackages.chocolatey.org/api/v2/" disabled="false" user="customer" password="bogus/encrypted+value=" priority="10" />
+  </sources>
+  <features>
+    <feature name="checksumFiles" enabled="true" setExplicitly="false" description="Checksum files when pulled in from internet (based on package)." />
+    <feature name="virusCheckFiles" enabled="false" setExplicitly="false" />
+    <feature name="autoUninstaller" enabled="true" setExplicitly="true" description="Uninstall from programs and features without requiring an explicit uninstall script." />
+    <feature name="allowGlobalConfirmation" enabled="false" setExplicitly="true" description="Prompt for confirmation in scripts or bypass." />
+    <feature name="allowInsecureConfirmation" enabled="false" setExplicitly="false" />
+    <feature name="failOnAutoUninstaller" enabled="false" setExplicitly="false" description="Fail if automatic uninstaller fails." />
+    <feature name="failOnStandardError" enabled="false" setExplicitly="false" description="Fail if install provider writes to stderr." />
+    <feature name="powershellHost" enabled="true" setExplicitly="false" description="Use Chocolatey''s built-in PowerShell host." />
+    <feature name="logEnvironmentValues" enabled="false" setExplicitly="false" description="Log Environment Values - will log values of environment before and after install (could disclose sensitive data)." />
+    <feature name="virusCheck" enabled="true" setExplicitly="true" description="Virus Check - perform virus checking on downloaded files. Available in 0.9.10+. Licensed versions only." />
+    <feature name="downloadCache" enabled="true" setExplicitly="false" description="Download Cache - use the private download cache if available for a package. Available in 0.9.10+. Licensed versions only." />
+    <feature name="failOnInvalidOrMissingLicense" enabled="false" setExplicitly="false" description="Fail On Invalid Or Missing License - allows knowing when a license is expired or not applied to a machine." />
+    <feature name="ignoreInvalidOptionsSwitches" enabled="true" setExplicitly="false" description="Ignore Invalid Options/Switches - If a switch or option is passed that is not recognized, should choco fail?" />
+    <feature name="usePackageExitCodes" enabled="true" setExplicitly="false" description="Use Package Exit Codes - Package scripts can provide exit codes. With this on, package exit codes will be what choco uses for exit when non-zero (this value can come from a dependency package). Chocolatey defines valid exit codes as 0, 1605, 1614, 1641, 3010. With this feature off, choco will exit with a 0 or a 1 (matching previous behavior). Available in 0.9.10+." />
+  </features>
+  <apiKeys>
+    <apiKeys source="https://chocolatey.org/" key="bogus/encrypted+value=" />
+ </apiKeys>
+</chocolatey>
+  EOT
+  }
+
+  let (:newer_choco_version) {'0.9.10.0'}
+  let (:minimum_supported_version_priority) {'0.9.9.9'}
+  let (:last_unsupported_version_priority) {'0.9.9.8'}
+  let (:minimum_supported_version) {'0.9.9.0'}
+  let (:last_unsupported_version) {'0.9.8.33'}
+
+  before :each do
+    PuppetX::Chocolatey::ChocolateyCommon.stubs(:choco_version).returns(minimum_supported_version)
+
+    @provider = provider.new(resource)
+    resource.provider = @provider
+
+    # Stub all file and config tests
+    provider.stubs(:healthcheck)
+  end
+
+  context "verify provider" do
+    it "should be an instance of Puppet::Type::Chocolateysource::ProviderWindows" do
+
+      @provider.must be_an_instance_of Puppet::Type::Chocolateysource::ProviderWindows
+    end
+
+    it "should have a create method" do
+      @provider.should respond_to(:create)
+    end
+
+    it "should have an exists? method" do
+      @provider.should respond_to(:exists?)
+    end
+
+    it "should have a disable method" do
+      @provider.should respond_to(:disable)
+    end
+
+    it "should have a destroy method" do
+      @provider.should respond_to(:destroy)
+    end
+
+    it "should have a properties method" do
+      @provider.should respond_to(:properties)
+    end
+
+    it "should have a query method" do
+      @provider.should respond_to(:query)
+    end
+  end
+
+  context "properties" do
+
+    context ":location" do
+      it "should default to :name" do
+        resource[:location].should eq name
+      end
+
+      it "should accept c:\\packages" do
+        resource[:location] = 'c:\packages'
+      end
+
+      it "should accept http://somelocation/packages" do
+        resource[:location] = 'http://somelocation/packages'
+      end
+
+      it "should accept \\\\unc\\share\\packages" do
+        resource[:location] = '\\unc\share\packages'
+      end
+    end
+
+    context ":user" do
+      it "should accept 'bob'" do
+        resource[:user] = 'bob'
+      end
+
+      it "should accept 'domain\\bob'" do
+        resource[:user] = 'domain\bob'
+      end
+
+      it "should accept api keys like 'api123-456-243 d123'" do
+        resource[:user] = 'api123-456-243 d123'
+      end
+    end
+
+    context ":password" do
+      it "should accept 'bob'" do
+        resource[:password] = 'bob'
+      end
+
+      it "should accept api keys like 'api123-456-243 d123'" do
+        resource[:password] = 'api123-456-243 d123'
+      end
+    end
+  end
+
+  context "self.get_sources" do
+    before :each do
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:set_env_chocolateyinstall)
+    end
+
+    it "should error when the config file location is null" do
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_config_file).returns(nil)
+
+      expect {
+        provider.get_sources
+      }.to raise_error(Puppet::ResourceError, /Config file not found for Chocolatey/)
+    end
+
+    it "should error when the config file is not found" do
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_config_file).returns(choco_config)
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:file_exists?).with(choco_config).returns(false)
+
+      expect {
+        provider.get_sources
+      }.to raise_error(Puppet::ResourceError, /was unable to locate config file at/)
+    end
+
+    context "when getting sources from the config file" do
+      sources = []
+
+      before :each do
+        PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_config_file).returns(choco_config)
+        PuppetX::Chocolatey::ChocolateyCommon.expects(:file_exists?).with(choco_config).returns(true)
+        File.expects(:new).with(choco_config,"r").returns choco_config_contents
+
+        sources = provider.get_sources
+      end
+
+      it "should match the count of sources in the config" do
+        sources.count.must eq 3
+
+      end
+
+      it "should contain xml elements" do
+        sources[0].must be_an_instance_of REXML::Element
+      end
+    end
+  end
+
+  context "self.get_source" do
+    let (:element) {  REXML::Element.new('source') }
+    element_id = "default"
+    element_value= "c:\\packages"
+    element_disabled = "false"
+    element_priority = "10"
+    element_user = "thisguy"
+    element_password = "super/encrypted+value=="
+
+
+    before :each do
+      element.add_attributes( { "id"        => element_id,
+                                "value"     => element_value,
+                                "disabled"  => element_disabled,
+                                "priority"  => element_priority,
+                                "user"      => element_user,
+                                "password"  => element_password
+                              } )
+    end
+
+    it "should return nil source when element it nil" do
+      provider.get_source(nil).must be == {}
+    end
+
+    it "should convert an element to a source" do
+      source = provider.get_source(element)
+
+      source[:name].must eq element_id
+      source[:location].must eq element_value
+      source[:priority].must eq element_priority
+      source[:user].must eq element_user
+      source[:ensure].must eq :present
+    end
+
+    it "should convert a bare bones element to a source" do
+      element.delete_attribute('disabled')
+      element.delete_attribute('priority')
+      element.delete_attribute('user')
+      element.delete_attribute('password')
+
+      source = provider.get_source(element)
+
+      source[:name].must eq element_id
+      source[:location].must eq element_value
+      source[:ensure].must eq :present
+    end
+
+    it "when source is disabled" do
+      element.delete_attribute('disabled')
+      element.add_attribute('disabled', 'true')
+
+      source = provider.get_source(element)
+      source[:ensure].must eq :disabled
+    end
+  end
+
+  context ".validation" do
+    it "should not warn when both user/password are empty" do
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(minimum_supported_version)
+      Puppet.expects(:warning).never
+      Puppet.expects(:debug).never
+
+      resource.provider.validate
+    end
+
+    it "should throw when choco version is less than the minimum supported version" do
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(last_unsupported_version)
+
+      expect {
+        resource.provider.validate
+      }.to raise_error(Puppet::Error, /Chocolatey version must be '0.9.9.0' to manage configuration values with Puppet/)
+    end
+
+    it "should write a debug message on password when password is not empty" do
+      resource[:user] = 'tim'
+      resource[:password] = 'tim'
+
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(newer_choco_version)
+      Puppet.expects(:warning).never
+      Puppet.expects(:debug).with("The password is not ensurable, so Puppet is unable to change the value using chocolateysource resource. As a workaround, a password change can be in the form of an exec. Reference Chocolateysource[#{name}]")
+
+      resource.provider.validate
+    end
+
+    it "should not warn on user/password on newer choco versions" do
+      resource[:user] = 'tim'
+      resource[:password] = 'tim'
+
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(newer_choco_version)
+      Puppet.expects(:warning).never
+
+      resource.provider.validate
+    end
+
+    it "should not warn on user/password when choco version is the minimum supported version" do
+      resource[:user] = 'tim'
+      resource[:password] = 'tim'
+
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(minimum_supported_version)
+      Puppet.expects(:warning).never
+
+      resource.provider.validate
+    end
+
+    it "should not warn if priority is not set" do
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(newer_choco_version)
+      Puppet.expects(:warning).never
+
+      resource.provider.validate
+    end
+
+    it "should not warn if priority is not set on older unsupported versions" do
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(last_unsupported_version_priority)
+      Puppet.expects(:warning).never
+
+      resource.provider.validate
+    end
+
+    it "should not warn if priority is 0 on unsupported versions" do
+      resource[:priority] = 0
+
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(last_unsupported_version_priority)
+      Puppet.expects(:warning).never
+
+      resource.provider.validate
+    end
+
+    it "should not warn on priority when choco version is newer than the minimum supported version" do
+      resource[:priority] = 10
+
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(newer_choco_version)
+      Puppet.expects(:warning).never
+
+      resource.provider.validate
+    end
+
+    it "should not warn on priority when choco version is the minimum supported version" do
+      resource[:priority] = 10
+
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(minimum_supported_version_priority)
+      Puppet.expects(:warning).never
+
+      resource.provider.validate
+    end
+
+    it "should warn on priority when choco version is less than the minimum supported version" do
+      resource[:priority] = 10
+
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(last_unsupported_version_priority)
+      Puppet.expects(:warning).with("Chocolatey is unable to manage priority for sources when version is less than 0.9.9.9. The value you set will be ignored.")
+
+      resource.provider.validate
+    end
+  end
+
+  context ".flush" do
+    resource_name = "yup"
+    resource_location = "loc"
+    resource_ensure = :present
+    resource_priority = 10
+    resource_user = "thatguy"
+    resource_password = "secrets!"
+
+    before :each do
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:set_env_chocolateyinstall).at_most_once
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_config_file).returns(choco_config).at_most_once
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:file_exists?).with(choco_config).returns(true).at_most_once
+      File.expects(:new).with(choco_config,"r").returns(choco_config_contents).at_most_once
+
+      resource[:name] = resource_name
+      resource[:location] = resource_location
+      resource[:ensure] = resource_ensure
+    end
+
+    it "should ensure a source is present with minimal values set" do
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(newer_choco_version)
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'source', 'add',
+                                                      '--name', resource_name,
+                                                      '--source', resource_location,
+                                                      '--priority', 0,
+                                                     ])
+
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'source', 'enable',
+                                                      '--name', 'yup'
+                                                     ])
+
+      resource.flush
+    end
+
+    it "should ensure a source is present with all values set" do
+      resource[:priority] = resource_priority
+      resource[:user] = resource_user
+      resource[:password] = resource_password
+
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(newer_choco_version)
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'source', 'add',
+                                                      '--name', resource_name,
+                                                      '--source', resource_location,
+                                                      '--user', resource_user,
+                                                      '--password', resource_password,
+                                                      '--priority', resource_priority,
+                                                     ])
+
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'source', 'enable',
+                                                      '--name', resource_name
+                                                     ])
+
+      resource.flush
+    end
+
+    it "should set priority when present" do
+      resource[:priority] = resource_priority
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(newer_choco_version)
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'source', 'add',
+                                                      '--name', resource_name,
+                                                      '--source', resource_location,
+                                                      '--priority', resource_priority,
+                                                     ])
+
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'source', 'enable',
+                                                      '--name', resource_name
+                                                     ])
+
+      resource.flush
+    end
+
+    it "should set user and password when user is present" do
+      resource[:user] = resource_user
+      resource[:password] = resource_password
+
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(newer_choco_version)
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'source', 'add',
+                                                      '--name', resource_name,
+                                                      '--source', resource_location,
+                                                      '--user', resource_user,
+                                                      '--password', resource_password,
+                                                      '--priority', 0,
+                                                     ])
+
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'source', 'enable',
+                                                      '--name', resource_name
+                                                     ])
+
+      resource.flush
+    end
+
+    it "should set user and password when choco version is newer than the minimum supported version" do
+      resource[:user] = resource_user
+      resource[:password] = resource_password
+
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(newer_choco_version)
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'source', 'add',
+                                                      '--name', resource_name,
+                                                      '--source', resource_location,
+                                                      '--user', resource_user,
+                                                      '--password', resource_password,
+                                                      '--priority', 0,
+                                                     ])
+
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'source', 'enable',
+                                                      '--name', resource_name
+                                                     ])
+
+      resource.flush
+    end
+
+    it "should set user and password when choco version is the minimum supported version" do
+      resource[:user] = resource_user
+      resource[:password] = resource_password
+
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(minimum_supported_version)
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'source', 'add',
+                                                      '--name', resource_name,
+                                                      '--source', resource_location,
+                                                      '--user', resource_user,
+                                                      '--password', resource_password,
+                                                     ])
+
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'source', 'enable',
+                                                      '--name', resource_name
+                                                     ])
+
+      resource.flush
+    end
+
+    it "should set priority when choco version is newer than the minimum supported version" do
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(newer_choco_version)
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'source', 'add',
+                                                      '--name', resource_name,
+                                                      '--source', resource_location,
+                                                      '--priority', 0,
+                                                     ])
+
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'source', 'enable',
+                                                      '--name', resource_name,
+                                                     ])
+
+      resource.flush
+    end
+
+    it "should set priority when choco version is the minimum supported version" do
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(minimum_supported_version_priority)
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'source', 'add',
+                                                      '--name', resource_name,
+                                                      '--source', resource_location,
+                                                      '--priority', 0,
+                                                     ])
+
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'source', 'enable',
+                                                      '--name', resource_name,
+                                                     ])
+
+      resource.flush
+    end
+
+    it "should not set priority when choco version is less than the minimum supported version" do
+      resource[:priority] = resource_priority
+
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(last_unsupported_version_priority)
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'source', 'add',
+                                                      '--name', resource_name,
+                                                      '--source', resource_location,
+                                                     ])
+
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'source', 'enable',
+                                                      '--name', resource_name,
+                                                     ])
+
+      resource.flush
+    end
+
+    it "should disable a source when ensure => disabled" do
+      resource.provider.disable
+
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(newer_choco_version)
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'source', 'add',
+                                                      '--name', resource_name,
+                                                      '--source', resource_location,
+                                                      '--priority', 0,
+                                                     ])
+
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'source', 'disable',
+                                                      '--name', 'yup'
+                                                     ])
+
+      resource.flush
+    end
+
+    it "should remove a source when ensure => absent" do
+      resource.provider.destroy
+
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).never
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'source', 'remove',
+                                                      '--name', resource_name,
+                                                     ])
+
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'source', 'enable',
+                                                      '--name', 'yup'
+                                                     ]).never
+
+      resource.flush
+    end
+
+    it "should provide an error message when choco execution fails" do
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(newer_choco_version)
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'source', 'add',
+                                                      '--name', resource_name,
+                                                      '--source', resource_location,
+                                                      '--priority', 0,
+                                                     ]).raises(Puppet::ExecutionFailure, "Nooooo")
+
+      expect { resource.flush }.to raise_error(Puppet::Error, /Unable to set Chocolatey source/)
+    end
+  end
+end

--- a/spec/unit/puppet/provider/package/chocolatey_spec.rb
+++ b/spec/unit/puppet/provider/package/chocolatey_spec.rb
@@ -1,6 +1,6 @@
-# vim: set ts=2 sw=2 ai et ruler:
 require 'spec_helper'
 require 'stringio'
+require 'puppet/type/package'
 require 'puppet/provider/package/chocolatey'
 
 provider = Puppet::Type.type(:package).provider(:chocolatey)

--- a/spec/unit/puppet/type/chocolateysource_spec.rb
+++ b/spec/unit/puppet/type/chocolateysource_spec.rb
@@ -1,0 +1,129 @@
+require 'spec_helper'
+require 'puppet/type/chocolateysource'
+
+describe Puppet::Type.type(:chocolateysource) do
+  let(:resource) { Puppet::Type.type(:chocolateysource).new(:name => "source") }
+  let(:provider) { Puppet::Provider.new(resource) }
+  let(:catalog) { Puppet::Resource::Catalog.new }
+  let (:minimum_supported_version) {'0.9.9.0'}
+
+  before :each do
+    PuppetX::Chocolatey::ChocolateyCommon.stubs(:choco_version).returns(minimum_supported_version)
+
+    resource.provider = provider
+  end
+
+  it "should be an instance of Puppet::Type::Chocolateysource" do
+    resource.must be_an_instance_of Puppet::Type::Chocolateysource
+  end
+
+  it "parameter :name should be the name var" do
+    resource.parameters[:name].isnamevar?.should be_truthy
+  end
+
+  #string values
+  ['name','location','user','password'].each do |param|
+    context "parameter :#{param}" do
+      let (:param_symbol) { param.to_sym }
+
+      it "should accept any string value" do
+        resource[param_symbol] = 'value'
+        resource[param_symbol] = "c:/thisstring-location/value/somefile.txt"
+        resource[param_symbol] = "c:\\thisstring-location\\value\\somefile.txt"
+      end
+    end
+  end
+
+  #numeric values
+  ['priority'].each do |param|
+    context "parameter :#{param}" do
+      let (:param_symbol) { param.to_sym }
+
+      it "should accept any numeric value" do
+        resource[param_symbol] = 0
+        resource[param_symbol] = 10
+      end
+
+      it "should accept any string that represents a numeric value" do
+        resource[param_symbol] = '1'
+        resource[param_symbol] = '0'
+      end
+
+      it "should not accept other string values" do
+        expect {
+          resource[param_symbol] = 'value'
+        }.to raise_error(Puppet::Error, /An integer is necessary for #{param}/)
+      end
+
+      it "should not accept symbol values" do
+        expect {
+          resource[param_symbol] = :whenever
+        }.to raise_error(Puppet::Error, /An integer is necessary for #{param}/)
+      end
+    end
+  end
+
+  context "param :ensure" do
+    it "should accept 'present'" do
+      resource[:ensure] = 'present'
+    end
+
+    it "should accept present" do
+      resource[:ensure] = :present
+    end
+
+    it "should accept :disabled" do
+      resource[:ensure] = :disabled
+    end
+
+    it "should accept absent" do
+      resource[:ensure] = :absent
+    end
+
+    it "should reject any other value" do
+      expect {
+        resource[:ensure] = :whenever
+      }.to raise_error(Puppet::Error, /Invalid value :whenever. Valid values are/)
+    end
+  end
+
+  it "should autorequire Exec[install_chocolatey_official] when in the catalog" do
+    exec = Puppet::Type.type(:exec).new(:name => "install_chocolatey_official", :path => "nope")
+    catalog.add_resource resource
+    catalog.add_resource exec
+
+    reqs = resource.autorequire
+    reqs.count.must == 1
+    reqs[0].source.must == exec
+    reqs[0].target.must == resource
+  end
+
+  context ".validate" do
+      it "should pass when both user/password are empty" do
+        resource.validate
+      end
+
+      it "should pass when both user/password have a value" do
+        resource[:user] = 'tim'
+        resource[:password] = 'tim'
+
+        resource.validate
+      end
+
+      it "should fail when user has a value but password does not" do
+        resource[:user] = 'tim'
+
+        expect {
+          resource.validate
+        }.to raise_error(ArgumentError, /you must specify both values/)
+      end
+
+      it "should fail when password has a value but user does not" do
+        resource[:password] = 'tim'
+
+        expect {
+          resource.validate
+        }.to raise_error(ArgumentError, /you must specify both values/)
+      end
+  end
+end

--- a/spec/unit/puppet_x/chocolatey/chocolatey_common_spec.rb
+++ b/spec/unit/puppet_x/chocolatey/chocolatey_common_spec.rb
@@ -1,0 +1,71 @@
+require 'spec_helper'
+require 'puppet_x/chocolatey/chocolatey_install'
+require 'puppet_x/chocolatey/chocolatey_common'
+
+describe 'Chocolatey Common' do
+
+  let (:first_compiled_choco_version) {'0.9.9.0'}
+  let (:newer_choco_version) {'0.9.10.0'}
+  let (:last_posh_choco_version) {'0.9.8.33'}
+
+  before :each do
+    PuppetX::Chocolatey::ChocolateyCommon.stubs(:set_env_chocolateyinstall)
+  end
+
+  context ".chocolatey_command" do
+    it "should find chocolatey install location based on PuppetX::Chocolatey::ChocolateyInstall", :if => Puppet.features.microsoft_windows? do
+      PuppetX::Chocolatey::ChocolateyInstall.expects(:install_path).returns('c:\dude')
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:file_exists?).with('c:\dude\bin\choco.exe').returns(true)
+
+      PuppetX::Chocolatey::ChocolateyCommon.chocolatey_command.should == 'c:\dude\bin\choco.exe'
+    end
+
+    it "should find chocolatey install location based on default location", :if => Puppet.features.microsoft_windows? do
+      PuppetX::Chocolatey::ChocolateyInstall.expects(:install_path).returns('c:\dude')
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:file_exists?).with('c:\dude\bin\choco.exe').returns(false)
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:file_exists?).with('C:\ProgramData\chocolatey\bin\choco.exe').returns(false)
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:file_exists?).with('C:\Chocolatey\bin\choco.exe').returns(false)
+
+      PuppetX::Chocolatey::ChocolateyCommon.chocolatey_command.should == "#{ENV['ALLUSERSPROFILE']}\\chocolatey\\bin\\choco.exe"
+    end
+  end
+
+  context ".choco_version" do
+    it "should return PuppetX::Chocolatey::ChocolateyVersion.version" do
+      expected = '0.9.9.0.1'
+      PuppetX::Chocolatey::ChocolateyVersion.expects(:version).returns(expected)
+      PuppetX::Chocolatey::ChocolateyCommon.clear_cached_values
+
+      PuppetX::Chocolatey::ChocolateyCommon.choco_version.must eq expected
+    end
+  end
+
+  context ".choco_config_file" do
+    let (:choco_install_loc) { 'c:\dude' }
+
+    it "should return the normal config file location when found" do
+      expected = 'c:\dude\config\chocolatey.config'
+      PuppetX::Chocolatey::ChocolateyInstall.expects(:install_path).returns(choco_install_loc)
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:file_exists?).with(expected).returns(true)
+
+      PuppetX::Chocolatey::ChocolateyCommon.choco_config_file.must eq expected
+    end
+
+    it "should return the old config file location for older installs" do
+      expected = 'c:\dude\chocolateyinstall\chocolatey.config'
+      PuppetX::Chocolatey::ChocolateyInstall.expects(:install_path).returns(choco_install_loc)
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:file_exists?).with('c:\dude\config\chocolatey.config').returns(false)
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:file_exists?).with(expected).returns(true)
+
+      PuppetX::Chocolatey::ChocolateyCommon.choco_config_file.must eq expected
+    end
+
+    it "should return nil when the config cannot be found" do
+      PuppetX::Chocolatey::ChocolateyInstall.expects(:install_path).returns(choco_install_loc)
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:file_exists?).with('c:\dude\config\chocolatey.config').returns(false)
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:file_exists?).with('c:\dude\chocolateyinstall\chocolatey.config').returns(false)
+
+      PuppetX::Chocolatey::ChocolateyCommon.choco_config_file.must be_nil
+    end
+  end
+end

--- a/spec/unit/puppet_x/chocolatey/chocolatey_install_spec.rb
+++ b/spec/unit/puppet_x/chocolatey/chocolatey_install_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+require 'puppet_x/chocolatey/chocolatey_install'
+
+describe 'Chocolatey Install Location' do
+
+  context 'on Windows', :if => Puppet::Util::Platform.windows? do
+
+    it "should return install path from registry if it exists" do
+      expected_value = 'C:\somewhere'
+      Win32::Registry.any_instance.expects(:[]).with('ChocolateyInstall').returns(expected_value)
+
+      PuppetX::Chocolatey::ChocolateyInstall.install_path.must == expected_value
+    end
+
+    it "should return the default install path if environment variable does not exist" do
+      expected_value = 'C:\ProgramData\chocolatey'
+      Win32::Registry.any_instance.expects(:[]).with('ChocolateyInstall').raises(Win32::Registry::Error.new(2), 'file not found yo')
+
+      PuppetX::Chocolatey::ChocolateyInstall.install_path.must == expected_value
+    end
+  end
+
+  context 'on Linux', :if => Puppet.features.posix? do
+    it "should return the default install path on a non-windows system" do
+      PuppetX::Chocolatey::ChocolateyInstall.install_path.must == 'C:\ProgramData\chocolatey'
+    end
+  end
+end

--- a/spec/unit/puppet_x/chocolatey/chocolatey_install_spec.rb
+++ b/spec/unit/puppet_x/chocolatey/chocolatey_install_spec.rb
@@ -12,17 +12,41 @@ describe 'Chocolatey Install Location' do
       PuppetX::Chocolatey::ChocolateyInstall.install_path.must == expected_value
     end
 
-    it "should return the default install path if environment variable does not exist" do
-      expected_value = 'C:\ProgramData\chocolatey'
+    it "should return the environment variable ChocolateyInstall if it exists" do
       Win32::Registry.any_instance.expects(:[]).with('ChocolateyInstall').raises(Win32::Registry::Error.new(2), 'file not found yo')
 
-      PuppetX::Chocolatey::ChocolateyInstall.install_path.must == expected_value
+      # this is a placeholder, it is already set in spec_helper
+      ENV['ChocolateyInstall'] = 'c:\blah'
+
+      PuppetX::Chocolatey::ChocolateyInstall.install_path.must == 'c:\blah'
+    end
+
+    it "should return nil if the environment variable does not exist" do
+      Win32::Registry.any_instance.expects(:[]).with('ChocolateyInstall').raises(Win32::Registry::Error.new(2), 'file not found yo')
+      ENV['ChocolateyInstall'] = nil
+
+      PuppetX::Chocolatey::ChocolateyInstall.install_path.must be_nil
     end
   end
 
   context 'on Linux', :if => Puppet.features.posix? do
-    it "should return the default install path on a non-windows system" do
-      PuppetX::Chocolatey::ChocolateyInstall.install_path.must == 'C:\ProgramData\chocolatey'
+    it "should return the environment variable ChocolateyInstall if it exists" do
+      # this is a placeholder, it is already set in spec_helper
+      ENV['ChocolateyInstall'] = 'c:\blah'
+
+      PuppetX::Chocolatey::ChocolateyInstall.install_path.must == 'c:\blah'
+    end
+
+    it "should return nil if the ChocolateyInstall variable does not exist" do
+      ENV['ChocolateyInstall'] = nil
+
+      PuppetX::Chocolatey::ChocolateyInstall.install_path.must be_nil
     end
   end
+
+  after :each do
+    # setting the values back
+    ENV['ChocolateyInstall'] = 'c:\blah'
+  end
+
 end

--- a/spec/unit/puppet_x/chocolatey/chocolatey_version_spec.rb
+++ b/spec/unit/puppet_x/chocolatey/chocolatey_version_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+require 'puppet_x/chocolatey/chocolatey_version'
+
+describe 'Chocolatey Version' do
+
+  context 'on Windows', :if => Puppet::Util::Platform.windows? do
+
+    context "when Chocolatey is installed" do
+      before :each do
+        PuppetX::Chocolatey::ChocolateyInstall.expects(:install_path).returns('c:\dude')
+        File.expects(:exist?).with('c:\dude\bin\choco.exe').returns(true)
+      end
+
+      it "should return the value from running choco -v" do
+        expected_value = '1.2.3'
+        Puppet::Util::Execution.expects(:execute).returns(expected_value)
+
+        PuppetX::Chocolatey::ChocolateyVersion.version.must == expected_value
+      end
+
+      it "should handle cleaning up spaces" do
+        expected_value = '1.2.3'
+        Puppet::Util::Execution.expects(:execute).returns(' ' + expected_value + ' ')
+
+        PuppetX::Chocolatey::ChocolateyVersion.version.must == expected_value
+      end
+
+      it "should handle older versions of choco" do
+        expected_value = '1.2.3'
+        Puppet::Util::Execution.expects(:execute).returns('Please run chocolatey /? or chocolatey help - chocolatey v' + expected_value)
+
+        PuppetX::Chocolatey::ChocolateyVersion.version.must == expected_value
+      end
+
+      it "should handle 0.9.8.33 of choco" do
+        expected_value = '1.2.3'
+        Puppet::Util::Execution.expects(:execute).returns('!!ATTENTION!!
+The next version of Chocolatey (v0.9.9) will require -y to perform
+  behaviors that change state without prompting for confirmation. Start
+  using it now in your automated scripts.
+
+  For details on the all new Chocolatey, visit http://bit.ly/new_choco
+Please run chocolatey /? or chocolatey help - chocolatey v' + expected_value)
+
+        PuppetX::Chocolatey::ChocolateyVersion.version.must == expected_value
+      end
+    end
+
+    context "When Chocolatey is not installed" do
+      before :each do
+        PuppetX::Chocolatey::ChocolateyInstall.expects(:install_path).returns(nil)
+        File.expects(:exist?).with('\bin\choco.exe').returns(false)
+      end
+
+      it "should return nil" do
+        PuppetX::Chocolatey::ChocolateyVersion.version.must be_nil
+      end
+    end
+
+  end
+
+  context 'on Linux', :if => Puppet.features.posix? do
+    it "should return nil on a non-windows system" do
+      PuppetX::Chocolatey::ChocolateyVersion.version.must be_nil
+    end
+  end
+end


### PR DESCRIPTION
Provide the ability manage a source with a custom type and provider.
This allows a source to be ensurable, and also allows for a source to
be manageable in the same converge that Chocolatey is installed
during. This further allows for installing packages from custom
sources all in the same Puppet run.