### PR TITLE
(MODULES-3161) Add rake tests task

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,22 @@
-require 'puppet/version'
+require 'rake'
 require 'rspec/core/rake_task'
 require 'puppetlabs_spec_helper/rake_tasks'
+begin
+  require 'beaker/tasks/test' unless RUBY_PLATFORM =~ /win32/
+rescue LoadError
+  #Do nothing, only installed with system_tests group 
+end
+
+task :default => [:test]
+
+desc 'Run RSpec'
+RSpec::Core::RakeTask.new(:test) do |t|
+  t.pattern = 'spec/{unit}/**/*.rb'
+#  t.rspec_opts = ['--color']
+end
+
+desc 'Generate code coverage'
+RSpec::Core::RakeTask.new(:coverage) do |t|
+  t.rcov = true
+  t.rcov_opts = ['--exclude', 'spec']
+end


### PR DESCRIPTION
This commit adds the usual rake tasks from the ACL
module into the chocolatey module.  The test rake
test is required by Puppetlabs build pipelines.