### PR TITLE
(MODULES-3209) Modify metadata with minimum specifications

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,13 +1,13 @@
 {
-  "name": "chocolatey-chocolatey",
-  "version": "1.2.1",
+  "name": "puppetlabs-chocolatey",
+  "version": "0.0.1",
   "author": "chocolatey",
-  "summary": "The Chocolatey package provider for Puppet",
+  "summary": "Chocolatey package provider for Puppet",
   "license": "Apache-2.0",
   "source": "https://github.com/chocolatey/puppet-chocolatey",
   "project_page": "https://github.com/chocolatey/puppet-chocolatey",
   "issues_url": "https://github.com/chocolatey/puppet-chocolatey/issues",
-  "description": "The Chocolatey package provider for Puppet",
+  "description": "Chocolatey package provider for Puppet",
   "tags": [
     "microsoft",
     "powershell",
@@ -21,19 +21,17 @@
   "requirements": [
     {
       "name": "pe",
-      "version_requirement": ">= 2.7.0 < 2015.4.0"
+      "version_requirement": ">= 3.0.0 < 2015.4.0"
     },
     {
       "name": "puppet",
-      "version_requirement": ">= 2.7.0 < 5.0.0"
+      "version_requirement": ">= 3.0.0 < 5.0.0"
     }
   ],
   "operatingsystem_support": [
     {
       "operatingsystem": "Windows",
       "operatingsystemrelease": [
-        "Server 2003",
-        "Server 2003 R2",
         "Server 2008",
         "Server 2008 R2",
         "Server 2012",


### PR DESCRIPTION
This commit modifies the module metadata to reflect the module's
minimum specifications;

- Windows Server 2003 is not supported
- Puppet below 3.0 is not supported

This commit also changes the module namespace to puppetlabs and
changes the version back to 0.0.1 as this is the first time this
module has been authored.