### PR TITLE
(MODULES-3161) Add acceptance test harness

### DIFF
--- a/acceptance/.beaker-git.cfg
+++ b/acceptance/.beaker-git.cfg
@@ -1,0 +1,9 @@
+{
+  :type            => 'git',
+  :pre_suite       => ['./acceptance/setup/install.rb'],
+  :hosts_file      => './acceptance/config/windows-2012r2-x86_64.cfg',
+  :log_level       => 'debug',
+  :tests           => './acceptance/tests',
+  :keyfile         => '~/.ssh/id_rsa-acceptance',
+  :timeout         => 6000
+}

--- a/acceptance/.beaker-pe.cfg
+++ b/acceptance/.beaker-pe.cfg
@@ -1,0 +1,9 @@
+{
+  :type            => 'pe',
+  :pre_suite       => ['./acceptance/setup/install.rb'],
+  :hosts_file      => './acceptance/config/windows-2012r2-x86_64.cfg',
+  :log_level       => 'debug',
+  :tests           => './acceptance/tests',
+  :keyfile         => '~/.ssh/id_rsa-acceptance',
+  :timeout         => 6000
+}

--- a/acceptance/config/windows-2008r2-x86_64.cfg
+++ b/acceptance/config/windows-2008r2-x86_64.cfg
@@ -1,0 +1,23 @@
+HOSTS:
+  ubuntu1204:
+    roles:
+      - master
+      - database
+      - dashboard
+    platform: ubuntu-12.04-amd64
+    template: ubuntu-1204-x86_64
+    hypervisor: vcloud
+  w2008r2:
+    roles:
+      - agent
+    platform: windows-2008r2-x86_64
+    template: win-2008r2-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  pe_dir: http://neptune.puppetlabs.lan/3.3/ci-ready/

--- a/acceptance/config/windows-2012r2-core-x86_64.cfg
+++ b/acceptance/config/windows-2012r2-core-x86_64.cfg
@@ -1,0 +1,24 @@
+HOSTS:
+  debian6:
+    roles:
+      - master
+      - database
+      - agent
+      - dashboard
+    platform: debian-6-i386
+    template: debian-6-i386
+    hypervisor: vcloud
+  w2012:
+    roles:
+      - agent
+    platform: windows-2012r2-core-x86_64
+    template: win-2012r2-core-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  pe_dir: http://neptune.puppetlabs.lan/3.2/ci-ready/

--- a/acceptance/config/windows-2012r2-x86_64.cfg
+++ b/acceptance/config/windows-2012r2-x86_64.cfg
@@ -1,0 +1,24 @@
+HOSTS:
+  debian6:
+    roles:
+      - master
+      - database
+      - agent
+      - dashboard
+    platform: debian-6-i386
+    template: debian-6-i386
+    hypervisor: vcloud
+  w2012r2:
+    roles:
+      - agent
+    platform: windows-2012r2-x86_64
+    template: win-2012r2-x86_64
+    hypervisor: vcloud
+CONFIG:
+  nfs_server: none
+  consoleport: 443
+  datastore: instance0
+  folder: Delivery/Quality Assurance/Enterprise/Dynamic
+  resourcepool: delivery/Quality Assurance/Enterprise/Dynamic
+  pooling_api: http://vcloud.delivery.puppetlabs.net/
+  pe_dir: http://neptune.puppetlabs.lan/3.3/ci-ready/

--- a/acceptance/scripts/beaker_command_w2008r2x64.sh
+++ b/acceptance/scripts/beaker_command_w2008r2x64.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+beaker \
+  --pre-suite ../setup/pe_install.rb \
+  --config ../config/windows-2008r2-x86_64.cfg \
+  --debug \
+  --tests ../tests \
+  --keyfile ~/.ssh/id_rsa-acceptance \
+  --preserve-hosts onfail \
+  --timeout 6000

--- a/acceptance/scripts/beaker_command_w2012r2x64.sh
+++ b/acceptance/scripts/beaker_command_w2012r2x64.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+beaker \
+  --pre-suite ../setup/pe_install.rb \
+  --config ../config/windows-2012r2-x86_64.cfg \
+  --debug \
+  --tests ../tests \
+  --keyfile ~/.ssh/id_rsa-acceptance \
+  --preserve-hosts onfail \
+  --timeout 6000

--- a/acceptance/setup/install.rb
+++ b/acceptance/setup/install.rb
@@ -1,0 +1,13 @@
+require 'beaker/puppet_install_helper'
+
+step 'Install Puppet'
+run_puppet_install_helper
+
+step 'Install Certs'
+install_ca_certs
+
+step 'Install Module'
+proj_root = File.expand_path(File.join(File.dirname(__FILE__), '../..'))
+hosts.each do |host|
+  install_dev_puppet_module_on(host, :source => proj_root, :module_name => 'chocolatey')
+end

--- a/acceptance/tests/chocolatey_spec.rb
+++ b/acceptance/tests/chocolatey_spec.rb
@@ -1,0 +1,1 @@
+# Empty acceptance test


### PR DESCRIPTION
This commit adds the files necessary for the acceptance beaker tests
for CI.  An initial blank test file is included which will always pass.
It is expected that the test suite will be filled out in later commits.

These files originally came from the puppetlabs-acl module.