### PR TITLE
(MODULES-3043) add acceptance and reference test for choco install

### DIFF
--- a/tests/acceptance/pre-suite/00_pe_install.rb
+++ b/tests/acceptance/pre-suite/00_pe_install.rb
@@ -1,6 +1,11 @@
 require 'master_manipulator'
 test_name 'MODULES-3138 - C48 - Install Puppet Enterprise'
 
+# Check for a master before continuing
+if master == nil
+  fail_test("Master is not set, are you using a host configuration that has a master?")
+end
+
 # Init
 step 'Install PE'
 install_pe

--- a/tests/acceptance/pre-suite/02_chocolatey_application_install.rb
+++ b/tests/acceptance/pre-suite/02_chocolatey_application_install.rb
@@ -1,0 +1,47 @@
+require 'master_manipulator'
+require 'chocolatey_helper'
+test_name 'MODULES-3043 - C97739 - Install Client on Virgin System'
+
+chocolatey_pp = <<MANIFEST
+  class {'chocolatey':
+    chocolatey_download_url => 'file:///C:/chocolatey.nupkg',
+    use_7zip                => false,
+  }
+MANIFEST
+
+chocoVersion = /[0-9]+[\d'.']*/
+
+# Setup
+step 'Inject "site.pp" on Master'
+site_pp = create_site_pp(master, :manifest => chocolatey_pp)
+inject_site_pp(master, get_site_pp_path(master), site_pp)
+
+#Test
+confine_block(:to, :platform => 'windows') do
+
+  agents.each do |agent|
+    opts = {
+        :acceptable_exit_codes => [0, 2]
+    }
+
+    url = get_latest_chocholatey_download_url
+
+    step 'Download chocolatey nuget package' do
+      curl_on(agent, "#{url} > C:/chocolatey.nupkg")
+    end
+
+    step 'should apply chocolatey manifest and install choco.exe' do
+      on(agent, puppet('agent -t --environment production'), opts) do |result|
+        assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+      end
+    end
+
+    step 'should have valid version of Chocolatey' do
+      on(agent, 'C:/ProgramData/chocolatey/bin/choco.exe -v', :acceptable_exit_codes => 0) do |result|
+        assert_match(chocoVersion, result.stdout, 'Expected: ' + chocoVersion.to_s + ' but got ' + result.stdout)
+      end
+    end
+
+  end
+
+end

--- a/tests/lib/chocolatey_helper.rb
+++ b/tests/lib/chocolatey_helper.rb
@@ -1,0 +1,30 @@
+require 'net/http'
+require 'uri'
+require 'nokogiri'
+
+$chocolatey_latest_info_url = "http://nexus.delivery.puppetlabs.net/service/local/nuget/temp-build-tools/Packages()?$filter=((Id%20eq%20%27chocolatey%27)%20and%20(not%20IsPrerelease))%20and%20IsLatestVersion"
+
+# Extract the url for the latest Puppet hosted version of Chocolatey
+#
+# ==== Returns
+#
+# +string+ - url from the feed/content->src of the $chocolatey_latest_info_url
+#
+# ==== Raises
+#
+# URI::InvalidURIError
+#
+# ==== Examples
+#
+# url = get_latest_chocholatey_download_url;
+
+def get_latest_chocholatey_download_url()
+  uri = URI.parse($chocolatey_latest_info_url)
+
+  response = Net::HTTP.get_response(uri)
+  xml_str = Nokogiri::XML(response.body)
+
+  src_url = xml_str.css('//feed//content').attr('src')
+
+  return src_url
+end

--- a/tests/reference/pre-suite/03_chocolatey_application_install.rb
+++ b/tests/reference/pre-suite/03_chocolatey_application_install.rb
@@ -1,0 +1,39 @@
+require 'chocolatey_helper'
+
+test_name 'MODULES-3043 - C97739 - Install Client on Virgin System'
+
+confine(:to, :platform => 'windows')
+
+chocolatey_pp = <<MANIFEST
+  class {'chocolatey':
+    chocolatey_download_url => 'file:///C:/chocolatey.nupkg',
+    use_7zip                => false,
+  }
+MANIFEST
+
+
+chocoVersion = /[0-9]+[\d'.']*/
+
+agents.each do |agent|
+  opts = {
+    :acceptable_exit_codes => [0, 2]
+  }
+
+  url = get_latest_chocholatey_download_url;
+
+  step 'Download chocolatey nuget package' do
+    curl_on(agent, "#{url} > C:/chocolatey.nupkg")
+  end
+
+  step 'should apply chocolatey manifest and install choco.exe' do
+    apply_manifest_on(agent, chocolatey_pp, opts) do |result|
+      assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
+    end
+  end
+
+  step 'should have valid version of Chocolatey' do
+    on(agent, 'C:/ProgramData/chocolatey/bin/choco.exe -v', :acceptable_exit_codes => 0) do |result|
+      assert_match(chocoVersion, result.stdout, 'Expected: ' + chocoVersion.to_s + ' but got ' + result.stdout)
+    end
+  end
+end


### PR DESCRIPTION
Added reference and acceptance tests for installing the Chocolatey application via the Chocolatey Module.

https://tickets.puppetlabs.com/browse/MODULES-3043