### PR TITLE
Change templates to use windows 2008r2 without wmf5

### DIFF
--- a/tests/configs/windows-2008r2-64a
+++ b/tests/configs/windows-2008r2-64a
@@ -3,7 +3,7 @@ HOSTS:
     roles:
       - agent
     platform: windows-2008r2-x86_64
-    template: Delivery/Quality Assurance/Templates/vCloud/win-2008r2-wmf5-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/win-2008r2-x86_64
     hypervisor: vcloud
 CONFIG:
   masterless: true

--- a/tests/configs/windows-2008r2-64mda
+++ b/tests/configs/windows-2008r2-64mda
@@ -12,7 +12,7 @@ HOSTS:
     roles:
       - agent
     platform: windows-2008r2-x86_64
-    template: Delivery/Quality Assurance/Templates/vCloud/win-2008r2-wmf5-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/win-2008r2-x86_64
     hypervisor: vcloud
 CONFIG:
   nfs_server: none


### PR DESCRIPTION
WMF5 templates need updating, this will allow us to make the pipeline green, and test older versions of powershell before we update the vm templates with the latest version of wmf5.