### PR TITLE
(MODULES-3035) Manage configuration settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Travis | AppVeyor
     * [Package provider: Chocolatey](#package-provider-chocolatey)
     * [Chocolatey source configuration](#chocolateysource)
     * [Chocolatey feature configuration](#chocolateyfeature)
+    * [Chocolatey config configuration](#chocolateyconfig)
     * [Class: chocolatey](#class-chocolatey)
 6. [Limitations - OS compatibility, etc.](#limitations)
     * [Known Issues](#known-issues)
@@ -366,6 +367,57 @@ chocolateyfeature {'usefipscompliantchecksums':
 }
 ~~~
 
+#### Config Configuration
+You can configure config values that Chocolatey has available. Run
+`choco config list` to see the config settings available (just the
+config settings section).
+
+Requires Chocolatey v0.9.10.0+.
+
+##### Set Cache Location
+
+Cache location defaults to the TEMP directory. Set an explicit directory
+to cache downloads to instead of the default.
+
+~~~puppet
+chocolateyconfig {'cachelocation':
+  value  => "c:\\downloads",
+}
+~~~
+
+##### Unset Cache Location
+
+Remove cache location setting to go back to default.
+
+~~~puppet
+chocolateyconfig {'cachelocation':
+  ensure => absent,
+}
+~~~
+
+##### Use an Explicit Proxy
+
+When using Chocolatey behind a proxy, set `proxy` and optionally
+`proxyUser`/`proxyPassword` as well.
+
+**NOTE:** `proxyPassword` value is not verifiable.
+
+~~~puppet
+chocolateyconfig {'proxy':
+  value  => 'https://someproxy.com',
+}
+
+chocolateyconfig {'proxyUser':
+  value  => 'bob',
+}
+
+# not verifiable
+chocolateyconfig {'proxyPassword':
+  value  => 'securepassword',
+}
+~~~
+
+
 ### Packages
 
 #### With All Options
@@ -553,8 +605,8 @@ What state the package should be in. You can choose which package to retrieve by
 specifying a version number or `latest` as the ensure value. This defaults to
 `installed`.
 
-Valid options: `present` (also called `installed`), `absent`, `latest` or a version
-number.
+Valid options: `present` (also called `installed`), `absent`, `latest`,
+`held` or a version number.
 
 ##### `install_options`
 An array of additional options to pass when installing a package. These options are
@@ -684,6 +736,38 @@ The name of the feature. Used for uniqueness.
 What state the feature should be in.
 
 Valid options: `enabled` or `disabled`.
+
+
+### ChocolateyConfig
+Allows managing config settings for Chocolatey. Configuration values
+provide settings for users to configure aspects of Chocolatey and the
+way it functions. Similar to features, except allow for user configured
+values. Learn more about config settings at
+[Config](https://chocolatey.org/docs/commands-config). Requires
+Chocolatey v0.9.9.9+.
+
+#### Properties/Parameters
+
+##### `name`
+(**Namevar**: If ommitted, this attribute's value will default to the resource's
+title.)
+
+The name of the config setting. Used for uniqueness. Puppet is not able to
+easily manage any values that include Password in the key name in them as they
+will be encrypted in the configuration file.
+
+##### `ensure`
+(**Property**: This attribute represents concrete state on the target system.)
+
+What state the config should be in. This defaults to `present`.
+
+Valid options: `present` or `absent`.
+
+##### `value`
+(**Property**: This attribute represents concrete state on the target system.)
+
+The value of the config setting. If the name includes "password", then the value
+is not ensurable due to being encrypted in the configuration file.
 
 
 ### Class: chocolatey

--- a/lib/puppet/provider/chocolateyconfig/windows.rb
+++ b/lib/puppet/provider/chocolateyconfig/windows.rb
@@ -1,0 +1,140 @@
+require 'puppet/type'
+require 'pathname'
+require 'rexml/document'
+
+Puppet::Type.type(:chocolateyconfig).provide(:windows) do
+  confine :operatingsystem => :windows
+  defaultfor :operatingsystem => :windows
+
+  require Pathname.new(__FILE__).dirname + '../../../' + 'puppet_x/chocolatey/chocolatey_common'
+  include PuppetX::Chocolatey::ChocolateyCommon
+
+  CONFIG_MINIMUM_SUPPORTED_CHOCO_VERSION = '0.9.10.0'
+
+  commands :chocolatey => PuppetX::Chocolatey::ChocolateyCommon.chocolatey_command
+
+  def initialize(value={})
+    super(value)
+    @property_flush = {}
+  end
+
+  def properties
+    if @property_hash.empty?
+      @property_hash = query || { :ensure => ( :absent )}
+      @property_hash[:ensure] = :absent if @property_hash.empty?
+    end
+    @property_hash.dup
+  end
+
+  def query
+    self.class.configs.each do |config|
+      return config.properties if @resource[:name][/\A\S*/].downcase == config.name.downcase
+    end
+
+    return {}
+  end
+
+  def self.get_configs
+    PuppetX::Chocolatey::ChocolateyCommon.set_env_chocolateyinstall
+
+    choco_config = PuppetX::Chocolatey::ChocolateyCommon.choco_config_file
+    raise Puppet::ResourceError, "Config file not found for Chocolatey. Please make sure you have Chocolatey installed." if choco_config.nil?
+    raise Puppet::ResourceError, "An install was detected, but was unable to locate config file at #{choco_config}." unless PuppetX::Chocolatey::ChocolateyCommon.file_exists?(choco_config)
+
+    Puppet.debug("Gathering sources from '#{choco_config}'.")
+    config = REXML::Document.new File.new(choco_config, 'r')
+
+    config.elements.to_a( '//add' )
+  end
+
+  def self.get_config(element)
+    config = {}
+    return config if element.nil?
+
+    config[:name] = element.attributes['key'] if element.attributes['key']
+    config[:value] = element.attributes['value'] if element.attributes['value']
+    config[:description] = element.attributes['description'] if element.attributes['description']
+
+    config[:ensure] = :present
+
+    Puppet.debug("Loaded config '#{config.inspect}'.")
+
+    config
+  end
+
+  def self.configs
+    @configs ||=  get_configs.collect do |item|
+      config = get_config(item)
+      new(config)
+    end
+  end
+
+  def self.refresh_configs
+    @configs = nil
+    self.configs
+  end
+
+  def self.instances
+    configs
+  end
+
+  def self.prefetch(resources)
+    instances.each do |provider|
+      if (resource = resources[provider.name])
+        resource.provider = provider
+      end
+    end
+  end
+
+  def create
+    @property_flush[:ensure] = :present
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+  def destroy
+    @property_flush[:ensure] = :absent
+  end
+
+  def validate
+    choco_version = Gem::Version.new(PuppetX::Chocolatey::ChocolateyCommon.choco_version)
+    if choco_version < Gem::Version.new(CONFIG_MINIMUM_SUPPORTED_CHOCO_VERSION)
+      raise Puppet::ResourceError, "Chocolatey version must be '#{CONFIG_MINIMUM_SUPPORTED_CHOCO_VERSION}' to manage configuration values. Detected '#{choco_version}' as your version. Please upgrade Chocolatey."
+    end
+  end
+
+  mk_resource_methods
+
+  def flush
+    choco_version = Gem::Version.new(PuppetX::Chocolatey::ChocolateyCommon.choco_version)
+
+    args = []
+    args << 'config'
+
+    command = 'set'
+    command = 'unset' if @property_flush[:ensure] == :absent
+
+    args << command
+    args << '--name' << resource[:name]
+
+    if @property_flush[:ensure] != :absent
+      args << '--value' << resource[:value]
+    end
+
+    begin
+      Puppet::Util::Execution.execute([command(:chocolatey), *args])
+    rescue Puppet::ExecutionFailure => e
+      raise Puppet::Error, "An error occurred running choco. Unable to set Chocolateyconfig[#{self.name}]: #{e}"
+    end
+
+    @property_hash.clear
+    @property_hash = { :ensure => ( @property_flush[:ensure] )}
+
+    @property_flush.clear
+
+    self.class.refresh_configs
+    @property_hash = query
+  end
+end

--- a/lib/puppet/type/chocolateyconfig.rb
+++ b/lib/puppet/type/chocolateyconfig.rb
@@ -1,0 +1,85 @@
+require 'puppet/type'
+require 'pathname'
+
+Puppet::Type.newtype(:chocolateyconfig) do
+
+  @doc = <<-'EOT'
+    Allows managing config settings for Chocolatey.
+    Configuration values provide settings for users
+    to configure aspects of Chocolatey and the way it
+    functions. Similar to features, except allow for user
+    configured values. Requires 0.9.10+. Learn more about
+    config at https://chocolatey.org/docs/commands-config
+  EOT
+
+  ensurable do
+    newvalue(:present)  { provider.create }
+    newvalue(:absent)   { provider.destroy }
+    defaultto :present
+
+    def retrieve
+      provider.properties[:ensure]
+    end
+
+  end
+
+  newparam(:name) do
+    desc "The name of the config setting. Used for uniqueness.
+      Puppet is not able to easily manage any values that
+      include Password in the key name in them as they
+      will be encrypted in the configuration file."
+
+    validate do |value|
+      if value.nil? or value.empty?
+        raise ArgumentError, "A non-empty name must be specified."
+      end
+    end
+
+    isnamevar
+
+    munge do |value|
+      value.downcase
+    end
+
+    def insync?(is)
+      is.downcase == should.downcase
+    end
+  end
+
+  newproperty(:value) do
+    desc "The value of the config setting. If the
+      name includes 'password', then the value is
+      not ensurable due to being encrypted in the
+      configuration file."
+
+    validate do |value|
+      if value.nil? or value.empty?
+        raise ArgumentError, "A non-empty value must be specified. To unset value, use ensure => absent"
+      end
+    end
+
+    def insync?(is)
+      if (resource[:name] =~ /password/i)
+        # If name contains password, it is
+        # always in sync if there is a value
+        return (is.nil? || is.empty?) == (should.nil? || should.empty?)
+      else
+        return is.downcase == should.downcase
+      end
+    end
+  end
+
+  validate do
+    if self[:ensure] != :absent
+      raise ArgumentError, "Unless ensure => absent, value is required." if self[:value].nil? || self[:value].empty?
+    end
+
+    if provider.respond_to?(:validate)
+      provider.validate
+    end
+  end
+
+  autorequire(:exec) do
+    ['install_chocolatey_official']
+  end
+end

--- a/spec/unit/puppet/provider/chocolateyconfig/windows_spec.rb
+++ b/spec/unit/puppet/provider/chocolateyconfig/windows_spec.rb
@@ -1,0 +1,255 @@
+require 'spec_helper'
+require 'stringio'
+require 'puppet/type/chocolateyconfig'
+require 'puppet/provider/chocolateyconfig/windows'
+require 'rexml/document'
+
+provider = Puppet::Type.type(:chocolateyconfig).provider(:windows)
+describe provider do
+  let (:name) { 'configItem' }
+  let (:resource) { Puppet::Type.type(:chocolateyconfig).new(:provider => :windows, :name => name, :value => "yes") }
+  let (:choco_config) { 'c:\choco.config' }
+  let (:choco_config_contents) { <<-'EOT'
+<?xml version="1.0" encoding="utf-8"?>
+<chocolatey xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <config>
+    <add key="cacheLocation" value="" description="Cache location if not TEMP folder." />
+    <add key="commandExecutionTimeoutSeconds" value="2700" description="Default timeout for command execution." />
+    <add key="containsLegacyPackageInstalls" value="true" description="Install has packages installed prior to 0.9.9 series." />
+    <add key="proxy" value="" description="Explicit proxy location." />
+    <add key="proxyUser" value="" description="Optional proxy user." />
+    <add key="proxyPassword" value="" description="Optional proxy password. Encrypted." />
+    <add key="virusCheckMinimumPositives" value="5" description="Minimum numer of scan result positives before flagging a binary as a possible virus. Available in 0.9.10+. Licensed versions only." />
+    <add key="virusScannerType" value="VirusTotal" description="Virus Scanner Type (Generic or VirusTotal). Defaults to VirusTotal for Pro. Available in 0.9.10+. Licensed versions only." />
+    <add key="genericVirusScannerPath" value="" description="The full path to the command line virus scanner executable. Used when virusScannerType is Generic. Available in 0.9.10+. Licensed versions only." />
+    <add key="genericVirusScannerArgs" value="[[File]]" description="The arguments to pass to the generic virus scanner. Use [[File]] for the file path placeholder. Used when virusScannerType is Generic. Available in 0.9.10+. Licensed versions only." />
+    <add key="genericVirusScannerValidExitCodes" value="0" description="The exit codes for the generic virus scanner when a file is not flagged. Separate with comma, defaults to 0. Used when virusScannerType is Generic. Available in 0.9.10+. Licensed versions only." />
+  </config>
+  <sources>
+    <source id="local" value="c:\packages" disabled="true" user="rob" password="bogus/encrypted+value=" priority="0" />
+    <source id="chocolatey" value="https://chocolatey.org/api/v2/" disabled="false" priority="0" />
+    <source id="chocolatey.licensed" value="https://licensedpackages.chocolatey.org/api/v2/" disabled="false" user="customer" password="bogus/encrypted+value=" priority="10" />
+  </sources>
+  <features>
+    <feature name="checksumFiles" enabled="true" setExplicitly="false" description="Checksum files when pulled in from internet (based on package)." />
+    <feature name="virusCheckFiles" enabled="false" setExplicitly="false" />
+    <feature name="autoUninstaller" enabled="true" setExplicitly="true" description="Uninstall from programs and features without requiring an explicit uninstall script." />
+    <feature name="allowGlobalConfirmation" enabled="false" setExplicitly="true" description="Prompt for confirmation in scripts or bypass." />
+    <feature name="allowInsecureConfirmation" enabled="false" setExplicitly="false" />
+    <feature name="failOnAutoUninstaller" enabled="false" setExplicitly="false" description="Fail if automatic uninstaller fails." />
+    <feature name="failOnStandardError" enabled="false" setExplicitly="false" description="Fail if install provider writes to stderr." />
+    <feature name="powershellHost" enabled="true" setExplicitly="false" description="Use Chocolatey''s built-in PowerShell host." />
+    <feature name="logEnvironmentValues" enabled="false" setExplicitly="false" description="Log Environment Values - will log values of environment before and after install (could disclose sensitive data)." />
+    <feature name="virusCheck" enabled="true" setExplicitly="true" description="Virus Check - perform virus checking on downloaded files. Available in 0.9.10+. Licensed versions only." />
+    <feature name="downloadCache" enabled="true" setExplicitly="false" description="Download Cache - use the private download cache if available for a package. Available in 0.9.10+. Licensed versions only." />
+    <feature name="failOnInvalidOrMissingLicense" enabled="false" setExplicitly="false" description="Fail On Invalid Or Missing License - allows knowing when a license is expired or not applied to a machine." />
+    <feature name="ignoreInvalidOptionsSwitches" enabled="true" setExplicitly="false" description="Ignore Invalid Options/Switches - If a switch or option is passed that is not recognized, should choco fail?" />
+    <feature name="usePackageExitCodes" enabled="true" setExplicitly="false" description="Use Package Exit Codes - Package scripts can provide exit codes. With this on, package exit codes will be what choco uses for exit when non-zero (this value can come from a dependency package). Chocolatey defines valid exit codes as 0, 1605, 1614, 1641, 3010. With this feature off, choco will exit with a 0 or a 1 (matching previous behavior). Available in 0.9.10+." />
+  </features>
+  <apiKeys>
+    <apiKeys source="https://chocolatey.org/" key="bogus/encrypted+value=" />
+ </apiKeys>
+</chocolatey>
+  EOT
+  }
+
+
+  let (:minimum_supported_version) {'0.9.10.0'}
+  let (:last_unsupported_version) {'0.9.9.12'}
+
+  before :each do
+    PuppetX::Chocolatey::ChocolateyCommon.stubs(:choco_version).returns(minimum_supported_version)
+
+    @provider = provider.new(resource)
+    resource.provider = @provider
+
+    # Stub all file and config tests
+    provider.stubs(:healthcheck)
+  end
+
+  context "verify provider" do
+    it "should be an instance of Puppet::Type::Chocolateyconfig::ProviderWindows" do
+      @provider.must be_an_instance_of Puppet::Type::Chocolateyconfig::ProviderWindows
+    end
+
+    it "should have a create method" do
+      @provider.should respond_to(:create)
+    end
+
+    it "should have an exists? method" do
+      @provider.should respond_to(:exists?)
+    end
+
+    it "should have a destroy method" do
+      @provider.should respond_to(:destroy)
+    end
+
+    it "should have a properties method" do
+      @provider.should respond_to(:properties)
+    end
+
+    it "should have a query method" do
+      @provider.should respond_to(:query)
+    end
+  end
+
+  context "properties" do
+    context ":value" do
+      #it "should default to nil" do
+      #  resource[:value].should be_nil
+      #end
+
+      it "should accept c:\\cache" do
+        resource[:value] = 'c:\cache'
+      end
+
+      it "should accept 2700" do
+        resource[:value] = '2700'
+      end
+
+      it "should accept 'value with spaces'" do
+        resource[:value] = 'value with spaces'
+      end
+    end
+  end
+
+  context "self.get_configs" do
+    before :each do
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:set_env_chocolateyinstall)
+    end
+
+    it "should error when the config file location is null" do
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_config_file).returns(nil)
+
+      expect {
+        provider.get_configs
+      }.to raise_error(Puppet::ResourceError, /Config file not found for Chocolatey/)
+    end
+
+    it "should error when the config file is not found" do
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_config_file).returns(choco_config)
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:file_exists?).with(choco_config).returns(false)
+
+      expect {
+        provider.get_configs
+      }.to raise_error(Puppet::ResourceError, /was unable to locate config file at/)
+    end
+
+    context "when getting configs from the config file" do
+      configs = []
+
+      before :each do
+        PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_config_file).returns(choco_config)
+        PuppetX::Chocolatey::ChocolateyCommon.expects(:file_exists?).with(choco_config).returns(true)
+        File.expects(:new).with(choco_config,"r").returns choco_config_contents
+
+        configs = provider.get_configs
+      end
+
+      it "should match the count of configs in the config" do
+        configs.count.must eq 11
+
+      end
+
+      it "should contain xml elements" do
+        configs[0].must be_an_instance_of REXML::Element
+      end
+    end
+  end
+
+  context "self.get_config" do
+    let (:element) {  REXML::Element.new('add') }
+    element_key = "cacheLocation"
+    element_value= "c:\\cache"
+    element_description = "Cache location if not TEMP folder."
+
+    before :each do
+      element.add_attributes( { "key"        => element_key,
+                                "value"     => element_value,
+                                "description"  => element_description,
+                              } )
+    end
+
+    it "should return nil config when element is nil" do
+      provider.get_config(nil).must be == {}
+    end
+
+    it "should convert an element to a config" do
+      config = provider.get_config(element)
+
+      config[:name].must eq element_key
+      config[:value].must eq element_value
+      config[:description].must eq element_description
+      config[:ensure].must eq :present
+    end
+  end
+
+  context ".validation" do
+    it "should not error when the minimum version is met" do
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(minimum_supported_version)
+
+      resource.provider.validate
+    end
+
+    it "should error when the minimum version is not met" do
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(last_unsupported_version)
+
+      expect {
+        resource.provider.validate
+      }.to raise_error(Puppet::ResourceError, /Chocolatey version must be '0.9.10.0' to manage configuration values. Detected '#{last_unsupported_version}'/)
+    end
+  end
+
+  context ".flush" do
+    resource_name = "yup"
+    resource_value = "this"
+    resource_ensure = :present
+
+    before :each do
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:set_env_chocolateyinstall).at_most_once
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_config_file).returns(choco_config).at_most_once
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:file_exists?).with(choco_config).returns(true).at_most_once
+      File.expects(:new).with(choco_config,"r").returns(choco_config_contents).at_most_once
+
+      resource[:name] = resource_name
+      resource[:value] = resource_value
+      resource[:ensure] = resource_ensure
+    end
+
+    it "should ensure a config setting is set" do
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(minimum_supported_version)
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'config', 'set',
+                                                      '--name', resource_name,
+                                                      '--value', resource_value
+                                                     ])
+
+      resource.flush
+    end
+
+    it "should ensure a config setting is removed" do
+      resource.provider.destroy
+
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(minimum_supported_version)
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'config', 'unset',
+                                                      '--name', resource_name
+                                                     ])
+
+      resource.flush
+    end
+
+    it "should provide an error message when choco execution fails" do
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(minimum_supported_version)
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'config', 'set',
+                                                      '--name', resource_name,
+                                                      '--value', resource_value
+                                                     ]).raises(Puppet::ExecutionFailure, "Nooooo")
+
+      expect { resource.flush }.to raise_error(Puppet::Error, /Unable to set Chocolateyconfig/)
+    end
+
+
+  end
+end

--- a/spec/unit/puppet/type/chocolateyconfig_spec.rb
+++ b/spec/unit/puppet/type/chocolateyconfig_spec.rb
@@ -1,0 +1,103 @@
+require 'spec_helper'
+require 'puppet/type/chocolateyconfig'
+
+describe Puppet::Type.type(:chocolateyconfig) do
+  let(:resource) { Puppet::Type.type(:chocolateyconfig).new(:name => "config", :ensure => :absent) }
+  let(:provider) { Puppet::Provider.new(resource) }
+  let(:catalog) { Puppet::Resource::Catalog.new }
+  let (:minimum_supported_version) {'0.9.10.0'}
+
+  before :each do
+    PuppetX::Chocolatey::ChocolateyCommon.stubs(:choco_version).returns(minimum_supported_version)
+
+    resource.provider = provider
+  end
+
+  it "should be an instance of Puppet::Type::Chocolateyconfig" do
+    resource.must be_an_instance_of Puppet::Type::Chocolateyconfig
+  end
+
+  it "parameter :name should be the name var" do
+    resource.parameters[:name].isnamevar?.should be_truthy
+  end
+
+  #string values
+  ['name','value'].each do |param|
+    context "parameter :#{param}" do
+      let (:param_symbol) { param.to_sym }
+
+      it "should not allow nil" do
+        expect {
+          resource[param_symbol] = nil
+        }.to raise_error(Puppet::Error, /Got nil value for #{param}/)
+      end
+
+      it "should not allow empty" do
+        expect {
+          resource[param_symbol] = ''
+        }.to raise_error(Puppet::Error, /A non-empty #{param} must/)
+      end
+
+      it "should accept any string value" do
+        resource[param_symbol] = 'value'
+        resource[param_symbol] = "c:/thisstring-location/value/somefile.txt"
+        resource[param_symbol] = "c:\\thisstring-location\\value\\somefile.txt"
+      end
+    end
+  end
+
+  context "param :ensure" do
+    it "should accept 'present'" do
+      resource[:ensure] = 'present'
+    end
+
+    it "should accept present" do
+      resource[:ensure] = :present
+    end
+
+    it "should accept absent" do
+      resource[:ensure] = :absent
+    end
+
+    it "should reject any other value" do
+      expect {
+        resource[:ensure] = :whenever
+      }.to raise_error(Puppet::Error, /Invalid value :whenever. Valid values are/)
+    end
+  end
+
+  it "should autorequire Exec[install_chocolatey_official] when in the catalog" do
+    exec = Puppet::Type.type(:exec).new(:name => "install_chocolatey_official", :path => "nope")
+    catalog.add_resource resource
+    catalog.add_resource exec
+
+    reqs = resource.autorequire
+    reqs.count.must == 1
+    reqs[0].source.must == exec
+    reqs[0].target.must == resource
+  end
+
+  context ".validate" do
+    it "should pass when ensure => absent with no value" do
+      resource[:ensure] = :absent
+
+      resource.validate
+    end
+
+    it "should pass when ensure => present with a value" do
+      resource[:ensure] = :present
+      resource[:value] = 'yo'
+
+      resource.validate
+    end
+
+    it "should fail when ensure => present with no value" do
+      resource[:ensure] = :present
+
+      expect {
+        resource.validate
+      }.to raise_error(ArgumentError, /Unless ensure => absent, value is required/)
+    end
+  end
+
+end

--- a/tests/lib/chocolatey_helper.rb
+++ b/tests/lib/chocolatey_helper.rb
@@ -2,7 +2,7 @@ require 'net/http'
 require 'uri'
 require 'nokogiri'
 
-$chocolatey_latest_info_url = "http://nexus.delivery.puppetlabs.net/service/local/nuget/temp-build-tools/Packages()?$filter=((Id%20eq%20%27chocolatey%27)%20and%20(not%20IsPrerelease))%20and%20IsLatestVersion"
+$chocolatey_latest_info_url = "http://nexus.delivery.puppetlabs.net/service/local/nuget/choco-pipeline-tests/Packages()?$filter=((Id%20eq%20%27chocolatey%27)%20and%20(not%20IsPrerelease))%20and%20IsLatestVersion"
 
 # Extract the url for the latest Puppet hosted version of Chocolatey
 #

--- a/tests/reference/tests/chocolateyconfig/add_new_config_item.rb
+++ b/tests/reference/tests/chocolateyconfig/add_new_config_item.rb
@@ -1,0 +1,29 @@
+require 'chocolatey_helper'
+test_name 'MODULES-3035 - Add New Config Item'
+confine(:to, :platform => 'windows')
+
+backup_config
+
+# arrange
+chocolatey_src = <<-PP
+  chocolateyconfig {'hello123':
+    ensure => present,
+    value  => 'this guy',
+  }
+PP
+
+# teardown
+teardown do
+  reset_config
+end
+
+# act
+step 'Apply manifest'
+apply_manifest(chocolatey_src, :catch_failures => true)
+
+step 'Verify results'
+agents.each do |agent|
+  on(agent, "cmd.exe /c \"type #{config_file_location}\"") do |result|
+    assert_match(/this guy/, get_xml_value("//config/add[@key='hello123']/@value", result.output).to_s, 'Value did not match')
+  end
+end

--- a/tests/reference/tests/chocolateyconfig/add_value_to_existing_config.rb
+++ b/tests/reference/tests/chocolateyconfig/add_value_to_existing_config.rb
@@ -1,0 +1,29 @@
+require 'chocolatey_helper'
+test_name 'MODULES-3035 - Add a Value to an Existing Config Setting'
+confine(:to, :platform => 'windows')
+
+backup_config
+
+# arrange
+chocolatey_src = <<-PP
+  chocolateyconfig {'proxy':
+    ensure => present,
+    value  => 'https://somewhere',
+  }
+PP
+
+# teardown
+teardown do
+  reset_config
+end
+
+# act
+step 'Apply manifest'
+apply_manifest(chocolatey_src, :catch_failures => true)
+
+step 'Verify results'
+agents.each do |agent|
+  on(agent, "cmd.exe /c \"type #{config_file_location}\"") do |result|
+    assert_match(/https\:\/\/somewhere/, get_xml_value("//config/add[@key='proxy']/@value", result.output).to_s, 'Value did not match')
+  end
+end

--- a/tests/reference/tests/chocolateyconfig/change_config_value.rb
+++ b/tests/reference/tests/chocolateyconfig/change_config_value.rb
@@ -1,0 +1,46 @@
+require 'chocolatey_helper'
+test_name 'MODULES-3035 - Config Settings Change Config Value'
+confine(:to, :platform => 'windows')
+
+backup_config
+
+# arrange
+chocolatey_src = <<-PP
+  chocolateyconfig {'proxyUser':
+    value => 'bob',
+  }
+PP
+
+# teardown
+teardown do
+  reset_config
+end
+
+# act
+step 'Apply manifest to setup'
+apply_manifest(chocolatey_src, :catch_failures => true)
+
+step 'Verify setup'
+agents.each do |agent|
+  on(agent, "cmd.exe /c \"type #{config_file_location}\"") do |result|
+    assert_match(/bob/, get_xml_value("//config/add[@key='proxyUser']/@value", result.output).to_s, 'Value did not match')
+  end
+end
+
+# arrange
+chocolatey_src_change = <<-PP
+  chocolateyconfig {'proxyuser':
+    value => 'tim',
+  }
+PP
+
+# act
+step 'Apply manifest to change config setting'
+apply_manifest(chocolatey_src_change, :catch_failures => true)
+
+step 'Verify results'
+agents.each do |agent|
+  on(agent, "cmd.exe /c \"type #{config_file_location}\"") do |result|
+    assert_match(/tim/, get_xml_value("//config/add[@key='proxyUser']/@value", result.output).to_s, 'Value did not change')
+  end
+end

--- a/tests/reference/tests/chocolateyconfig/ensure_config_value_with_password_in_name.rb
+++ b/tests/reference/tests/chocolateyconfig/ensure_config_value_with_password_in_name.rb
@@ -1,0 +1,50 @@
+require 'chocolatey_helper'
+test_name 'MODULES-3035 - Ensure Config Value with Password In Name'
+confine(:to, :platform => 'windows')
+
+backup_config
+
+# arrange
+chocolatey_src = <<-PP
+  chocolateyconfig {'proxypassword':
+    value => 'secrect',
+  }
+PP
+
+# teardown
+teardown do
+  reset_config
+end
+
+password = ''
+
+# act
+step 'Apply manifest to setup proxyPassword'
+apply_manifest(chocolatey_src, :catch_failures => true)
+
+step 'Verify setup'
+agents.each do |agent|
+  on(agent, "cmd.exe /c \"type #{config_file_location}\"") do |result|
+    password = get_xml_value("//config/add[@key='proxyPassword']/@value", result.output).to_s
+    assert_match(/.+/, password, 'Value did not match')
+  end
+end
+
+# arrange
+chocolatey_src_change = <<-PP
+  chocolateyconfig {'proxypassword':
+    value => 'secrect2',
+  }
+PP
+
+# act
+step 'Apply manifest to attempt to change proxyPassword - should have no effect'
+apply_manifest(chocolatey_src_change, :catch_failures => true)
+
+step 'Verify results'
+# should have no effect
+agents.each do |agent|
+  on(agent, "cmd.exe /c \"type #{config_file_location}\"") do |result|
+    assert_match(password, get_xml_value("//config/add[@key='proxyPassword']/@value", result.output).to_s, 'Value should not have changed')
+  end
+end

--- a/tests/reference/tests/chocolateyconfig/fail_to_appy_bad_manifest.rb
+++ b/tests/reference/tests/chocolateyconfig/fail_to_appy_bad_manifest.rb
@@ -1,0 +1,25 @@
+require 'chocolatey_helper'
+test_name 'MODULES-3035 - Fail to Apply Bad Manifest'
+confine(:to, :platform => 'windows')
+
+backup_config
+
+# arrange
+chocolatey_src = <<-PP
+  chocolateyconfig {'bob':
+    ensure => sad,
+    value  => 'yes',
+  }
+PP
+
+# teardown
+teardown do
+  reset_config
+end
+
+# act
+step 'Apply Manifest'
+apply_manifest(chocolatey_src, :expect_failures => true) do
+  step 'Verify Failure'
+  assert_match(/Error: Parameter ensure failed on Chocolateyconfig\[bob\]: Invalid value "sad"/, stderr, "stderr did not match expected")
+end

--- a/tests/reference/tests/chocolateyconfig/fail_to_set_present_without_value.rb
+++ b/tests/reference/tests/chocolateyconfig/fail_to_set_present_without_value.rb
@@ -1,0 +1,24 @@
+require 'chocolatey_helper'
+test_name 'MODULES-3035 - Fail to Set Present With No Value'
+confine(:to, :platform => 'windows')
+
+backup_config
+
+# arrange
+chocolatey_src = <<-PP
+  chocolateyconfig {'bob':
+    ensure => present,
+  }
+PP
+
+# teardown
+teardown do
+  reset_config
+end
+
+# act
+step 'Apply Manifest'
+apply_manifest(chocolatey_src, :expect_failures => true) do
+  step 'Verify Failure'
+  assert_match(/Error: Validation of Chocolateyconfig\[bob\] failed: Unless ensure => absent, value is required/, stderr, "stderr did not match expected")
+end

--- a/tests/reference/tests/chocolateyconfig/remove_config_value_with_password_in_name.rb
+++ b/tests/reference/tests/chocolateyconfig/remove_config_value_with_password_in_name.rb
@@ -1,0 +1,50 @@
+require 'chocolatey_helper'
+test_name 'MODULES-3035 - Config Settings Remove Value with Password in Name'
+confine(:to, :platform => 'windows')
+
+backup_config
+
+# arrange
+chocolatey_src = <<-PP
+  chocolateyconfig {'proxypassword':
+    value => 'secrect',
+  }
+PP
+
+# teardown
+teardown do
+  reset_config
+end
+
+password = ''
+
+# act
+step 'Apply manifest to setup proxyPassword'
+apply_manifest(chocolatey_src, :catch_failures => true)
+
+step 'Verify setup'
+agents.each do |agent|
+  on(agent, "cmd.exe /c \"type #{config_file_location}\"") do |result|
+    password = get_xml_value("//config/add[@key='proxyPassword']/@value", result.output).to_s
+    assert_match(/.+/, password, 'Value did not match')
+  end
+end
+
+# arrange
+chocolatey_src_change = <<-PP
+  chocolateyconfig {'proxypassword':
+    ensure => absent,
+  }
+PP
+
+# act
+step 'Apply manifest to remove proxyPassword'
+apply_manifest(chocolatey_src_change, :catch_failures => true)
+
+step 'Verify results'
+# should have no effect
+agents.each do |agent|
+  on(agent, "cmd.exe /c \"type #{config_file_location}\"") do |result|
+    assert_not_match(/.+/, get_xml_value("//config/add[@key='proxyPassword']/@value", result.output).to_s, 'Value should have been removed')
+  end
+end

--- a/tests/reference/tests/chocolateyconfig/remove_value_from_config.rb
+++ b/tests/reference/tests/chocolateyconfig/remove_value_from_config.rb
@@ -1,0 +1,28 @@
+require 'chocolatey_helper'
+test_name 'MODULES-3035 - Remove Value From Config Setting'
+confine(:to, :platform => 'windows')
+
+backup_config
+
+# arrange
+chocolatey_src = <<-PP
+  chocolateyconfig {'commandExecutionTimeoutSeconds':
+    ensure   => absent,
+  }
+PP
+
+# teardown
+teardown do
+  reset_config
+end
+
+# act
+step 'Apply manifest'
+apply_manifest(chocolatey_src, :catch_failures => true)
+
+step 'Verify results'
+agents.each do |agent|
+  on(agent, "cmd.exe /c \"type #{config_file_location}\"") do |result|
+    assert_not_match(/.+/, get_xml_value("//config/add[@key='commandExecutionTimeoutSeconds']/@value", result.output).to_s, 'Value did not match')
+  end
+end


### PR DESCRIPTION
~~Requires #1 to be merged first.~~

Provide the ability to manage config settings with a custom type and
provider. This allows a config setting to be ensurable, and also
allows for a config settings to be manageable in the same converge
that Chocolatey is installed during.

Things to accomplish:

- [x] Initial code
- [x] Specs
- [x] Documentation
- [x] Reference tests
- [x] insync? when the name includes Password  