### PR TITLE
(MODULES-3037) Confine install path fact w/default

### DIFF
--- a/lib/facter/choco_install_path.rb
+++ b/lib/facter/choco_install_path.rb
@@ -2,7 +2,8 @@ require 'pathname'
 require Pathname.new(__FILE__).dirname + '../' + 'puppet_x/chocolatey/chocolatey_install'
 
 Facter.add('choco_install_path') do
+  confine :osfamily => :windows
   setcode do
-    PuppetX::Chocolatey::ChocolateyInstall.install_path
+    PuppetX::Chocolatey::ChocolateyInstall.install_path || 'C:\ProgramData\chocolatey'
   end
 end

--- a/spec/unit/facter/choco_install_path_spec.rb
+++ b/spec/unit/facter/choco_install_path_spec.rb
@@ -10,11 +10,20 @@ describe 'choco_install_path fact' do
     Facter.clear_messages
   end
 
-  it "should return the output of PuppetX::Chocolatey::ChocolateyInstall.install_path" do
-    expected_value = 'C:\somewhere'
-    PuppetX::Chocolatey::ChocolateyInstall.expects(:install_path).returns(expected_value)
+  context "on Windows", :if => Puppet::Util::Platform.windows? do
+    it "should return the output of PuppetX::Chocolatey::ChocolateyInstall.install_path" do
+      expected_value = 'C:\somewhere'
+      PuppetX::Chocolatey::ChocolateyInstall.expects(:install_path).returns(expected_value)
 
-    subject.value.must == expected_value
+      subject.value.must == expected_value
+    end
+
+
+    it "should return the default path when PuppetX::Chocolatey::ChocolateyInstall.install_path is nil" do
+      PuppetX::Chocolatey::ChocolateyInstall.expects(:install_path).returns(nil)
+
+      subject.value.must == 'C:\ProgramData\chocolatey'
+    end
   end
 
   after :each do


### PR DESCRIPTION
Confine the choco_install_path to Windows osfamily (taking the the
example from other modules that do similar confines) and ensure that
the default is passed back if ChocolateyInstall.install_path comes back
nil.