### PR TITLE
(MODULES-3037) Acceptance tests - ChocolateySource

### DIFF
--- a/tests/reference/tests/chocolateysource/apply_manifest_without_location.rb
+++ b/tests/reference/tests/chocolateysource/apply_manifest_without_location.rb
@@ -1,0 +1,24 @@
+require 'chocolatey_helper'
+test_name 'MODULES-3037 - Add Source: Apply manifest without location'
+confine(:to, :platform => 'windows')
+
+backup_config
+
+# arrange
+chocolatey_src = <<-PP
+  chocolateysource {'chocolatey':
+    ensure   => present,
+  }
+PP
+
+# teardown
+teardown do
+  reset_config
+end
+
+# act
+step 'Apply Manifest'
+apply_manifest(chocolatey_src, :catch_failures => true) do
+  step 'Verify Result'
+  assert_match(/Notice: \/Stage\[main\]\/Main\/Chocolateysource\[chocolatey\]\/location: location changed 'https:\/\/chocolatey.org\/api\/v2\/' to 'chocolatey'/, stdout, "stdout did not match expected")
+end

--- a/tests/reference/tests/chocolateysource/fail_to_appy_bad_manifest.rb
+++ b/tests/reference/tests/chocolateysource/fail_to_appy_bad_manifest.rb
@@ -1,0 +1,25 @@
+require 'chocolatey_helper'
+test_name 'MODULES-3037 - Add Source Sad Path: Fail to apply bad manifest'
+confine(:to, :platform => 'windows')
+
+backup_config
+
+# arrange
+chocolatey_src = <<-PP
+  chocolateysource {'test':
+    ensure   => sad,
+    location => 'c:\\packages',
+  }
+PP
+
+# teardown
+teardown do
+  reset_config
+end
+
+# act
+step 'Apply Manifest'
+apply_manifest(chocolatey_src, :expect_failures => true) do
+  step 'Verify Failure'
+  assert_match(/Error: Parameter ensure failed on Chocolateysource\[test\]: Invalid value "sad"/, stderr, "stderr did not match expected")
+end

--- a/tests/reference/tests/chocolateysource/fail_to_set_password_without_user.rb
+++ b/tests/reference/tests/chocolateysource/fail_to_set_password_without_user.rb
@@ -1,0 +1,26 @@
+require 'chocolatey_helper'
+test_name 'MODULES-3037 - Add Source Sad Path: Set password with no user'
+confine(:to, :platform => 'windows')
+
+backup_config
+
+# arrange
+chocolatey_src = <<-PP
+  chocolateysource {'chocolatey':
+    ensure   => present,
+    location => 'https://chocolatey.org/api/v2',
+    password => 'test',
+  }
+PP
+
+# teardown
+teardown do
+  reset_config
+end
+
+# act
+step 'Apply Manifest'
+apply_manifest(chocolatey_src, :expect_failures => true) do
+  step 'Verify Failure'
+  assert_match(/Error: Validation of Chocolateysource\[chocolatey\] failed: If specifying user\/password, you must specify both values/, stderr, "stderr did not match expected")
+end

--- a/tests/reference/tests/chocolateysource/fail_to_set_user_without_password.rb
+++ b/tests/reference/tests/chocolateysource/fail_to_set_user_without_password.rb
@@ -1,0 +1,26 @@
+require 'chocolatey_helper'
+test_name 'MODULES-3037 - Add Source Sad Path: Set user with no password'
+confine(:to, :platform => 'windows')
+
+backup_config
+
+# arrange
+chocolatey_src = <<-PP
+  chocolateysource {'chocolatey':
+    ensure   => present,
+    location => 'https://chocolatey.org/api/v2',
+    user => 'tim',
+  }
+PP
+
+# teardown
+teardown do
+  reset_config
+end
+
+# act
+step 'Apply Manifest'
+apply_manifest(chocolatey_src, :expect_failures => true) do
+  step 'Verify Failure'
+  assert_match(/Error: Validation of Chocolateysource\[chocolatey\] failed: If specifying user\/password, you must specify both values/, stderr, "stderr did not match expected")
+end

--- a/tests/reference/tests/chocolateysource/remove_user_pass_from_existing_source.rb
+++ b/tests/reference/tests/chocolateysource/remove_user_pass_from_existing_source.rb
@@ -47,7 +47,7 @@ apply_manifest(chocolatey_src_remove, :catch_failures => true)
 step 'Verify results'
 agents.each do |agent|
   on(agent, "cmd.exe /c \"type #{config_file_location}\"") do |result|
-    assert_not_match(/tim/, get_xml_value("//sources/source[@id='chocolatey']/@user", result.output).to_s, 'User was not removed')
+    assert_not_match(/.+/, get_xml_value("//sources/source[@id='chocolatey']/@user", result.output).to_s, 'User was not removed')
     assert_not_match(/.+/, get_xml_value("//sources/source[@id='chocolatey']/@password", result.output).to_s, 'Password was not removed')
   end
 end


### PR DESCRIPTION
Adds negative tests for:
* applying a bad manifest
* trying to set a password with no user name
* trying to set a uersname with no password

Adds test for overwriting the source location. The default chocolatey behavior of overwriting source with the name
of a resource should be discussed.