### PR TITLE
(MODULES-3275) Chocolatey module testing

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -51,6 +51,8 @@ Gemfile:
       - gem: beaker
       - gem: master_manipulator
         version: '~> 1.2'
+      - gem: beaker-windows
+        version: '~> 0.6'
 Rakefile:
   unmanaged: true
 spec/spec_helper.rb:

--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ end
 group :system_tests do
   gem 'beaker', *location_for(ENV['BEAKER_VERSION'] || '~> 2.20')
   gem 'master_manipulator', '~> 1.2',  :require => false
+  gem 'beaker-windows', '~> 0.6', :require => false
 end
 
 # The recommendation is for PROJECT_GEM_VERSION, although there are older ways

--- a/tests/configs/windows-2012r2-64a
+++ b/tests/configs/windows-2012r2-64a
@@ -3,7 +3,7 @@ HOSTS:
     roles:
       - agent
     platform: windows-2012r2-x86_64
-    template: Delivery/Quality Assurance/Templates/vCloud/win-2012r2-wmf5-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/win-2012r2-x86_64
     hypervisor: vcloud
 CONFIG:
   masterless: true

--- a/tests/configs/windows-2012r2-64mda
+++ b/tests/configs/windows-2012r2-64mda
@@ -12,7 +12,7 @@ HOSTS:
     roles:
       - agent
     platform: windows-2012r2-x86_64
-    template: Delivery/Quality Assurance/Templates/vCloud/win-2012r2-wmf5-x86_64
+    template: Delivery/Quality Assurance/Templates/vCloud/win-2012r2-x86_64
     hypervisor: vcloud
 CONFIG:
   nfs_server: none

--- a/tests/reference/tests/chocolateypackage/install_and_remove_good_package.rb
+++ b/tests/reference/tests/chocolateypackage/install_and_remove_good_package.rb
@@ -1,0 +1,64 @@
+require 'chocolatey_helper'
+require 'beaker-windows'
+test_name 'MODULES-3037 - 97729 Install known good package via manifest and remove via manifest'
+confine(:to, :platform => 'windows')
+
+# arrange
+package_name = 'vlc'
+package_exe_path = %{C:\\'Program Files\\VideoLAN\\VLC\\vlc.exe'}
+package_uninstall_command = %{cmd.exe /C C:\\'Program Files\\VideoLAN\\VLC\\uninstall.exe' /S}
+
+chocolatey_package_manifest = <<-PP
+  package { "#{package_name}":
+    ensure  => present,
+    provider => chocolatey,
+    source => 'http://nexus.delivery.puppetlabs.net/service/local/nuget/choco-pipeline-tests/'
+  }
+PP
+
+# teardown
+teardown do
+  on(agent, exec_ps_cmd("test-path #{package_exe_path}")) do |result|
+      if (result.output =~ /True/i)
+        on(agent, exec_ps_cmd(package_uninstall_command))
+      end
+  end
+  on(agent, exec_ps_cmd("test-path #{package_exe_path}")) do |result|
+    assert_match(/False/i, result.output, "#{package_name} was present after uninstall command called.")
+  end
+end
+
+#validate
+step "should not have valid version of #{package_name}"
+on(agent, exec_ps_cmd("test-path #{package_exe_path}")) do |result|
+  assert_match(/False/i, result.output, "#{package_name} was present before application of manifest.")
+end
+
+
+#act
+step 'Apply manifest'
+apply_manifest(chocolatey_package_manifest, :catch_failures => true) do |result|
+  assert_match(/Notice\: \/Stage\[main\]\/Main\/Package\[#{package_name}\]\/ensure\: created/, result.stdout, "stdout did not report package creation of #{package_name}")
+end
+
+#validate
+step "should have valid version of #{package_name}"
+on(agent, exec_ps_cmd("test-path #{package_exe_path}")) do |result|
+  assert_match(/True/i, result.output, "#{package_name} was not present after application of manifest.")
+end
+
+#arrange
+chocolatey_package_manifest = <<-PP
+  package { "#{package_name}":
+    ensure  => absent,
+    provider => chocolatey,
+  }
+PP
+
+#act
+step "Uninstall #{package_name} package via manifest"
+apply_manifest(chocolatey_package_manifest, :catch_failures => true) do |result|
+#validate
+  assert_match(/Stage\[main\]\/Main\/Package\[#{package_name}\]\/ensure\: removed/, result.stdout, "stdout did not report package removal of #{package_name}")
+end
+

--- a/tests/reference/tests/chocolateypackage/install_and_remove_good_package_utf-8.rb
+++ b/tests/reference/tests/chocolateypackage/install_and_remove_good_package_utf-8.rb
@@ -1,0 +1,65 @@
+require 'chocolatey_helper'
+require 'beaker-windows'
+test_name 'MODULES-3037 - C97738 Install known good package with utf-8 via manifest and remove via manifest'
+confine(:to, :platform => 'windows')
+
+# arrange
+package_name = '竹ChocolateyGUIÖ'
+package_exe_path = %{C:\\'Program Files (x86)\\ChocolateyGUI\\ChocolateyGUI.exe'}
+package_uninstall_command = %{msiexec /x C:\\ProgramData\\chocolatey\\lib\\竹ChocolateyGUIÖ\\tools\\竹ChocolateyGUIÖ.msi /q}.force_encoding("ASCII-8BIT")
+
+chocolatey_package_manifest = <<-PP
+  package { "#{package_name}":
+    ensure  => present,
+    provider => chocolatey,
+    source => 'http://nexus.delivery.puppetlabs.net/service/local/nuget/choco-pipeline-tests/'
+  }
+PP
+
+# teardown
+teardown do
+  on(agent, exec_ps_cmd("test-path #{package_exe_path}")) do |result|
+    if (result.output =~ /True/i)
+      on(agent, exec_ps_cmd(package_uninstall_command))
+    end
+  end
+  on(agent, exec_ps_cmd("test-path #{package_exe_path}")) do |result|
+    assert_match(/False/i, result.output, "#{package_name} was present after uninstall.")
+  end
+end
+
+#validate
+step "should not have valid version of #{package_name}"
+on(agent, exec_ps_cmd("test-path #{package_exe_path}")) do |result|
+  assert_match(/False/i, result.output, "#{package_name} was present before application of manifest.")
+end
+
+
+#act
+step 'Apply manifest'
+apply_manifest(chocolatey_package_manifest, :catch_failures => true) do |result|
+  assert_match(/Notice\: \/Stage\[main\]\/Main\/Package\[#{package_name}\]\/ensure\: created/, result.stdout, "stdout did not report package creation of #{package_name}")
+end
+
+#validate
+step "should have valid version of #{package_name}"
+on(agent, exec_ps_cmd("test-path #{package_exe_path}")) do |result|
+  assert_match(/True/i, result.output, "#{package_name} was not present after application of manifest.")
+end
+
+#arrange
+chocolatey_package_manifest = <<-PP
+  package { "#{package_name}":
+    ensure  => absent,
+    provider => chocolatey,
+  }
+PP
+
+#act
+step "Uninstall #{package_name} package via manifest"
+apply_manifest(chocolatey_package_manifest, :catch_failures => true) do |result|
+#validate
+  expect_failure('Expected to fail because of MODULES-3541') do
+    assert_match(/Stage\[main\]\/Main\/Package\[#{package_name}\]\/ensure\: removed/, result.stdout, "stdout did not report package removal of #{package_name}")
+  end
+end

--- a/tests/reference/tests/hello.rb
+++ b/tests/reference/tests/hello.rb
@@ -1,7 +1,0 @@
-test_name "Hello Test"
-
-step "Say Hello"
-
-hosts.each do |host|
-  on(host, "echo hello!")
-end


### PR DESCRIPTION
Tests for installing and removing packages with and without UTF-8 characters.

Currently failing to apply the manifest correctly for package with UTF-8 characters, see  install_and_remove_good_package_utf-8.rb line 60.