### PR TITLE
(DO NOT MERGE) (MODULES-3391) Run all unit tests with `rake test`, address test failure

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,7 @@ task :default => [:test]
 
 desc 'Run RSpec'
 RSpec::Core::RakeTask.new(:test) do |t|
-  t.pattern = 'spec/{unit}/**/*.rb'
+  t.pattern = 'spec/{classes,defines,unit,functions,hosts,integration}/**/*_spec.rb'
 #  t.rspec_opts = ['--color']
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,6 +32,8 @@ RSpec.configure do |c|
   ENV['ChocolateyInstall'] = 'c:\blah'
 
   begin
+    Win32::Registry.any_instance.stubs(:[]).with('Bind')
+    Win32::Registry.any_instance.stubs(:[]).with('Domain')
     Win32::Registry.any_instance.stubs(:[]).with('ChocolateyInstall').raises(Win32::Registry::Error.new(2), 'file not found yo')
   rescue
     # we don't care


### PR DESCRIPTION
This PR extends the existing rspec test matcher in the `rake test` task to encompass all tests under the spec directory - or, more specifically, the exact matcher that rspec's built-in `Rake::Task` supplies, in order to give us full coverage with this task. This means it actually includes more directories than strictly exist under `spec`, but this perhaps is a bit of future proofing in case we ultimately add more subdirectories, e.g., `defines`. However, I'm happy to reduce this to the explicit set of directories that exist under `spec` if we think that's best.

This PR also resolves a failing test:
```

Mocha::ExpectationError:
unexpected invocation: #<AnyInstance:Win32::Registry>.[]('Domain')
satisfied expectations:
- allowed any number of times, invoked 4 times: #<AnyInstance:Win32::Registry>.[]('ChocolateyInstall')
- allowed any number of times, not yet invoked: #<Puppet::Util::Feature:0x45b5be0>.root?(any_parameters)
```
This is because facter fact(s) were making a call to `Win32::Registry.[]` which hadn't been stubbed (two, in fact). This commit adds these stubs to the spec_helper in addition to the existing one. This makes test pass, but may be more brittle than a more generic stub that doesn't specify the parameter. I assume we prefer higher specificity, but I'm happy to revise to a single line with just `Win32::Registry.any_instance.stubs(:[])` if preferred.