### PR TITLE
(MODULES-3641) Remove Windows_env module dependency

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,6 +2,5 @@ fixtures:
   forge_modules:
     stdlib:       "puppetlabs/stdlib"
     powershell:   "puppetlabs/powershell"
-    windows_env:  "badgerious/windows_env"
   symlinks:
     chocolatey: "#{source_dir}"

--- a/README.md
+++ b/README.md
@@ -211,6 +211,9 @@ class {'chocolatey':
 }
 ~~~
 
+**NOTE:** This will affect suitability on first install, see
+[`choco_install_location`](#choco_install_location) for details.
+
 #### Use an internal chocolatey.nupkg for Chocolatey installation
 
 ~~~puppet
@@ -788,6 +791,9 @@ Used for managing installation and configuration of Chocolatey itself.
 
 Where Chocolatey install should be located. This needs to be an absolute path starting with a drive letter e.g. `c:\`. Defaults to the currently detected install location based on the `ChocolateyInstall` environment variable, falls back to `'C:\ProgramData\chocolatey'`.
 
+**NOTE:** Puppet can install Chocolatey and configure Chocolatey/install packages during the same run *UNLESS* you specify this setting. This is due to the way the providers search for suitability of the command, falling back to the default install for the executable when none is found. Since environment variables and commands
+do not refresh during the same Puppet run (due somewhat to a Windows limitation with updating environment information for currently running processes), installing to a directory that is not the default won't be detected until the next time Puppet runs. So unless you really want this installed elsewhere and don't have a current existing install in that non-default location, the recommendation is not to set this value.
+
 ##### `use_7zip`
 
 Whether to use built-in shell or allow installer to download 7zip to extract `chocolatey.nupkg` during installation. Defaults to `true`.
@@ -813,6 +819,7 @@ Log output from the installer. Defaults to `false`.
 
 1. Works with Windows only.
 2. If you override an existing install location of Chocolatey using `choco_install_location =>` in the Chocolatey class, it does not bring any of the existing packages with it. You will need to handle that through some other means.
+3. Overriding the install location will also not allow Chocolatey to be configured or install packages on the same run that it is installed on. See [`choco_install_location`](#choco_install_location) for details.
 
 ### Known Issues
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -8,24 +8,6 @@ class chocolatey::install {
     default   => 'windows'
   }
 
-  # These are specifically necessary to ensure that we know the path
-  # has been updated in the current run. They are typically a noop.
-  windows_env { 'chocolatey_ChocolateyInstall_env':
-    ensure    => present,
-    variable  => 'ChocolateyInstall',
-    mergemode => 'clobber',
-    value     => $::chocolatey::choco_install_location,
-    notify    => Exec['install_chocolatey_official'],
-  }
-
-  windows_env { 'chocolatey_PATH_env':
-    ensure    => present,
-    variable  => 'PATH',
-    mergemode => 'prepend',
-    value     => "${::chocolatey::choco_install_location}\\bin",
-    notify    => Exec['install_chocolatey_official'],
-  }
-
   exec { 'install_chocolatey_official':
     command     => template('chocolatey/InstallChocolatey.ps1.erb'),
     creates     => "${::chocolatey::choco_install_location}\\bin\\choco.exe",

--- a/metadata.json
+++ b/metadata.json
@@ -52,10 +52,6 @@
     {
       "name": "puppetlabs/powershell",
       "version_requirement": ">= 1.0.1 < 3.0.0"
-    },
-    {
-      "name": "badgerious/windows_env",
-      "version_requirement": ">= 2.2.1 < 3.0.0"
     }
   ]
 }

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -10,21 +10,11 @@ RSpec.describe 'chocolatey' do
   }
 
   context 'contains install.pp' do
-    it { is_expected.to contain_windows_env('chocolatey_ChocolateyInstall_env').with_ensure('present') }
-    it { is_expected.to contain_windows_env('chocolatey_ChocolateyInstall_env').with_variable('ChocolateyInstall') }
-    it { is_expected.to contain_windows_env('chocolatey_ChocolateyInstall_env').that_notifies('Exec[install_chocolatey_official]') }
-
-    it { is_expected.to contain_windows_env('chocolatey_PATH_env').with_ensure('present') }
-    it { is_expected.to contain_windows_env('chocolatey_PATH_env').with_variable('PATH') }
-    it { is_expected.to contain_windows_env('chocolatey_PATH_env').that_notifies('Exec[install_chocolatey_official]') }
-
     ['c:\local_folder', "C:\\ProgramData\\chocolatey"].each do |param_value|
         context "choco_install_location => #{param_value}" do
         let(:params) {{ :choco_install_location => param_value }}
 
         it { is_expected.to contain_exec('install_chocolatey_official').with_creates("#{param_value}\\bin\\choco.exe") }
-        it { is_expected.to contain_windows_env('chocolatey_ChocolateyInstall_env').with_value("#{param_value}") }
-        it { is_expected.to contain_windows_env('chocolatey_PATH_env').with_value("#{param_value}\\bin") }
       end
     end
 


### PR DESCRIPTION
It was originally required to set the environment variables prior
to running Chocolatey install to help prepare the environment for
suitability. It was originally added in 5a849adca and ad57d1429
to ensure that Chocolatey could be suitable to be installed and
used to install packages on the first run. This was also to
ensure that you could override the Chocolatey install directory
by setting the value in advance of the install.

In b5034d167 @rismoney removed the necessity for pre-setting the
environment variable as it was passed to the install exec.

We have since determined that the providers default to a location
of `$env:ALLUSERSPROFILE\chocolatey\bin\choco.exe` when an install
path cannot be found. https://github.com/puppetlabs/puppetlabs-chocolatey/blob/fa67417bbfac06049f36346e02eb09dddb68084c/lib/puppet_x/chocolatey/chocolatey_common.rb#L31-L36
This evaluates to the default install path of
`C:\ProgramData\chocolatey\bin\choco.exe`, allowing suitability
to work properly on the same converge as the install ONLY if you
install to the default install location with Chocolatey. This
has nothing to do with the hope that windows_env would update
the current shell! So it is safe to remove windows_env without
losing any of the current behavior.