### PR TITLE
(Modules 3391) remove `rake test` and fix failing test

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -13,13 +13,7 @@ PuppetLint.configuration.send('disable_80chars')
 # Line length test is 140 chars in puppet-lint 2.x
 PuppetLint.configuration.send('disable_140chars')
 
-task :default => [:test]
-
-desc 'Run RSpec'
-RSpec::Core::RakeTask.new(:test) do |t|
-  t.pattern = 'spec/{unit}/**/*.rb'
-#  t.rspec_opts = ['--color']
-end
+task :default => [:spec]
 
 desc 'Generate code coverage'
 RSpec::Core::RakeTask.new(:coverage) do |t|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,6 +32,8 @@ RSpec.configure do |c|
   ENV['ChocolateyInstall'] = 'c:\blah'
 
   begin
+    Win32::Registry.any_instance.stubs(:[]).with('Bind')
+    Win32::Registry.any_instance.stubs(:[]).with('Domain')
     Win32::Registry.any_instance.stubs(:[]).with('ChocolateyInstall').raises(Win32::Registry::Error.new(2), 'file not found yo')
   rescue
     # we don't care


### PR DESCRIPTION
The bundle exec rake test command in the chocolatey Rakefile runs an incomplete set of tests with a missing dependency on `bundle exec rake spec_prep`. After further investigation, it turns out `puppetlabs_spec_helper` defines `rake spec` which runs all the spec tests and does appropriate prep setup/teardown. After discussing with @glennsarti and @ThoughtCrhyme it seems like the correct call here is to run `bundle exec rake spec` instead of extending `bundle exec rake test` to further duplicate it.

This PR specifically just removes the `rake test` task from Rakefile to avoid further confusion. It is believed that since the module is pre-1.0 this change, which might be considered backwards-incompatible is acceptable. I'm happy to work up something more backwards-compatible via task redirection if we think that's appropriate.

This PR also resolves a failing test:
```
Mocha::ExpectationError:
unexpected invocation: #<AnyInstance:Win32::Registry>.[]('Domain')
satisfied expectations:
- allowed any number of times, invoked 4 times: #<AnyInstance:Win32::Registry>.[]('ChocolateyInstall')
- allowed any number of times, not yet invoked: #<Puppet::Util::Feature:0x45b5be0>.root?(any_parameters)
```
This is because facter fact(s) were making a call to `Win32::Registry.[]` which hadn't been stubbed (two, in fact). This commit adds these stubs to the spec_helper in addition to the existing one. This makes test pass, but may be more brittle than a more generic stub that doesn't specify the parameter. I assume we prefer higher specificity, but I'm happy to revise to a single line with just `Win32::Registry.any_instance.stubs(:[])` if preferred.

Signed-off-by: Moses Mendoza <mendoza.moses@gmail.com>