### PR TITLE
(MODULES-3677) Ensure Chocolatey Config

### DIFF
--- a/lib/puppet_x/chocolatey/chocolatey_common.rb
+++ b/lib/puppet_x/chocolatey/chocolatey_common.rb
@@ -62,6 +62,10 @@ module PuppetX
         chocoInstallPath = PuppetX::Chocolatey::ChocolateyInstall.install_path
         choco_config = "#{chocoInstallPath}\\config\\chocolatey.config"
 
+        # choco may be installed, but a config file doesn't exist until the
+        # first run of choco - trigger that by checking the version
+        choco_run_ensure_config = choco_version
+
         return choco_config if file_exists?(choco_config)
 
         old_choco_config = "#{chocoInstallPath}\\chocolateyinstall\\chocolatey.config"


### PR DESCRIPTION
When Chocolatey has been installed and not yet run, the config file
doesn't exist. So chocolateyconfig, chocolateyfeature, and
chocolateysource will all fail until the config file exists.

Trigger a version check before returning the config file in
`PuppetX::Chocolatey::ChocolateyCommon.choco_config_file`. This
will ensure that an installed Chocolatey will have had the chance
to run at least one time if it is installed, thus ensuring the
config file's existence, allowing the providers to work without
erroring on a missing config file.