### PR TITLE
(MODULES-3758) Fix: chocolateysource user ensure sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,7 +639,7 @@ Specifies the name of the source. Used for uniqueness. Also sets the `location` 
 
 (**Property**: This parameter represents a concrete state on the target system.)
 
-Specifies what state the source should be in. Default: `present`. Valid options: `present`, `disabled`, or `absent`.
+Specifies what state the source should be in. Default: `present`. Valid options: `present`, `disabled`, or `absent`. `disabled` should only be used with existing sources.
 
 ##### `location`
 

--- a/lib/puppet/provider/chocolateyconfig/windows.rb
+++ b/lib/puppet/provider/chocolateyconfig/windows.rb
@@ -130,8 +130,6 @@ Puppet::Type.type(:chocolateyconfig).provide(:windows) do
     end
 
     @property_hash.clear
-    @property_hash = { :ensure => ( @property_flush[:ensure] )}
-
     @property_flush.clear
 
     self.class.refresh_configs

--- a/lib/puppet/provider/chocolateyconfig/windows.rb
+++ b/lib/puppet/provider/chocolateyconfig/windows.rb
@@ -113,13 +113,19 @@ Puppet::Type.type(:chocolateyconfig).provide(:windows) do
     args = []
     args << 'config'
 
+    # look at the hash, then flush if present.
+    # If all else fails, looks at resource[:ensure]
+    property_ensure = @property_hash[:ensure]
+    property_ensure = @property_flush[:ensure] if @property_flush[:ensure]
+    property_ensure = resource[:ensure] if property_ensure.nil?
+
     command = 'set'
-    command = 'unset' if @property_flush[:ensure] == :absent
+    command = 'unset' if property_ensure == :absent
 
     args << command
     args << '--name' << resource[:name]
 
-    if @property_flush[:ensure] != :absent
+    if property_ensure != :absent
       args << '--value' << resource[:value]
     end
 

--- a/lib/puppet/provider/chocolateyfeature/windows.rb
+++ b/lib/puppet/provider/chocolateyfeature/windows.rb
@@ -117,8 +117,6 @@ Puppet::Type.type(:chocolateyfeature).provide(:windows) do
     Puppet::Util::Execution.execute([command(:chocolatey), *args])
 
     @property_hash.clear
-    @property_hash = { :ensure => ( @property_flush[:ensure] )}
-
     @property_flush.clear
 
     self.class.features

--- a/lib/puppet/provider/chocolateysource/windows.rb
+++ b/lib/puppet/provider/chocolateysource/windows.rb
@@ -63,6 +63,7 @@ Puppet::Type.type(:chocolateysource).provide(:windows) do
     source[:priority] = 0
     source[:priority] = element.attributes['priority'].downcase if element.attributes['priority']
 
+    source[:user] = ''
     source[:user] = element.attributes['user'].downcase if element.attributes['user']
 
     Puppet.debug("Loaded source '#{source.inspect}'.")
@@ -160,7 +161,9 @@ Puppet::Type.type(:chocolateysource).provide(:windows) do
 
     if @property_flush[:ensure] != :absent
       command = 'enable'
-      command = 'disable' if @property_flush[:ensure] == :disabled
+      # use whatever the resource is set to for ensure - it won't be in
+      # property_flush unless it is changing
+      command = 'disable' if @resource[:ensure] == :disabled
       begin
         Puppet::Util::Execution.execute([command(:chocolatey), 'source', command, '--name', resource[:name]])
       rescue Puppet::ExecutionFailure

--- a/lib/puppet/provider/chocolateysource/windows.rb
+++ b/lib/puppet/provider/chocolateysource/windows.rb
@@ -16,6 +16,7 @@ Puppet::Type.type(:chocolateysource).provide(:windows) do
 
   def initialize(value={})
     super(value)
+
     @property_flush = {}
   end
 
@@ -172,12 +173,9 @@ Puppet::Type.type(:chocolateysource).provide(:windows) do
     end
 
     @property_hash.clear
-    @property_hash = { :ensure => ( @property_flush[:ensure] )}  #if  @property_flush[:ensure] == :absent
-
     @property_flush.clear
 
     self.class.refresh_sources
     @property_hash = query
   end
-
 end

--- a/lib/puppet/type/chocolateysource.rb
+++ b/lib/puppet/type/chocolateysource.rb
@@ -67,6 +67,10 @@ Puppet::Type.newtype(:chocolateysource) do
       same as setting the value to nil or not specifying
       the property at all."
 
+    def insync?(is)
+      is.downcase == should.downcase
+    end
+
     defaultto ''
   end
 
@@ -110,10 +114,6 @@ Puppet::Type.newtype(:chocolateysource) do
 
     if provider.respond_to?(:validate)
       provider.validate
-    end
-
-    if (self[:ensure].to_sym == :present && (self[:location].nil? || self[:location].strip == ''))
-      raise ArgumentError, "A non-empty location must be specified when ensure => present."
     end
   end
 

--- a/spec/unit/puppet/provider/chocolateysource/windows_spec.rb
+++ b/spec/unit/puppet/provider/chocolateysource/windows_spec.rb
@@ -339,6 +339,25 @@ describe provider do
 
       resource.provider.validate
     end
+
+    it "should pass when ensure is not present and location is empty" do
+      no_location_resource = Puppet::Type.type(:chocolateysource).new(:name => 'source', :ensure => :disabled )
+      no_location_resource.provider = provider.new(no_location_resource)
+
+      no_location_resource.provider.validate
+    end
+
+    it "should fail when ensure => present and location is empty" do
+      expect {
+        no_location_resource = Puppet::Type.type(:chocolateysource).new(:name => 'source')
+        no_location_resource.provider = provider.new(no_location_resource)
+
+        no_location_resource.provider.validate
+      }.to raise_error(Exception, /non-empty location/)
+      # check for just an exception here
+      # In some versions of Puppet, this comes back as ArgumentError
+      # In other versions of Puppet, this comes back as Puppet::Error
+    end
   end
 
   context ".flush" do

--- a/spec/unit/puppet/provider/chocolateysource/windows_spec.rb
+++ b/spec/unit/puppet/provider/chocolateysource/windows_spec.rb
@@ -556,19 +556,12 @@ describe provider do
 
     it "should disable a source when ensure => disabled" do
       resource[:ensure] = :disabled
+      resource[:name] = 'chocolatey'
       resource.provider.disable
-
-      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(newer_choco_version)
-      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
-                                                      'source', 'add',
-                                                      '--name', resource_name,
-                                                      '--source', resource_location,
-                                                      '--priority', 0,
-                                                     ])
 
       Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
                                                       'source', 'disable',
-                                                      '--name', 'yup'
+                                                      '--name', 'chocolatey'
                                                      ])
 
       resource.flush

--- a/spec/unit/puppet/provider/chocolateysource/windows_spec.rb
+++ b/spec/unit/puppet/provider/chocolateysource/windows_spec.rb
@@ -536,6 +536,7 @@ describe provider do
     end
 
     it "should disable a source when ensure => disabled" do
+      resource[:ensure] = :disabled
       resource.provider.disable
 
       PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(newer_choco_version)
@@ -555,6 +556,7 @@ describe provider do
     end
 
     it "should remove a source when ensure => absent" do
+      resource[:ensure] = :absent
       resource.provider.destroy
 
       PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).never

--- a/spec/unit/puppet/type/chocolateysource_spec.rb
+++ b/spec/unit/puppet/type/chocolateysource_spec.rb
@@ -99,44 +99,31 @@ describe Puppet::Type.type(:chocolateysource) do
   end
 
   context ".validate" do
-      it "should pass when both user/password are empty" do
+    it "should pass when both user/password are empty" do
+      resource.validate
+    end
+
+    it "should pass when both user/password have a value" do
+      resource[:user] = 'tim'
+      resource[:password] = 'tim'
+
+      resource.validate
+    end
+
+    it "should fail when user has a value but password does not" do
+      resource[:user] = 'tim'
+
+      expect {
         resource.validate
-      end
+      }.to raise_error(ArgumentError, /you must specify both values/)
+    end
 
-      it "should pass when both user/password have a value" do
-        resource[:user] = 'tim'
-        resource[:password] = 'tim'
+    it "should fail when password has a value but user does not" do
+      resource[:password] = 'tim'
 
+      expect {
         resource.validate
-      end
-
-      it "should fail when user has a value but password does not" do
-        resource[:user] = 'tim'
-
-        expect {
-          resource.validate
-        }.to raise_error(ArgumentError, /you must specify both values/)
-      end
-
-      it "should fail when password has a value but user does not" do
-        resource[:password] = 'tim'
-
-        expect {
-          resource.validate
-        }.to raise_error(ArgumentError, /you must specify both values/)
-      end
-
-      it "should pass when ensure is not present and location is empty" do
-        no_location_resource = Puppet::Type.type(:chocolateysource).new(:name => 'source', :ensure => :disabled )
-      end
-
-      it "should fail when ensure => present and location is empty" do
-        expect {
-          no_location_resource = Puppet::Type.type(:chocolateysource).new(:name => 'source')
-        }.to raise_error(Exception, /non-empty location/)
-        # check for just an exception here
-        # In some versions of Puppet, this comes back as ArgumentError
-        # In other versions of Puppet, this comes back as Puppet::Error
-      end
+      }.to raise_error(ArgumentError, /you must specify both values/)
+    end
   end
 end

--- a/tests/reference/tests/chocolateysource/disable_existing_source_two_runs.rb
+++ b/tests/reference/tests/chocolateysource/disable_existing_source_two_runs.rb
@@ -1,0 +1,43 @@
+require 'chocolatey_helper'
+test_name 'MODULES-3037 - Disable an Existing Source'
+confine(:to, :platform => 'windows')
+
+backup_config
+
+# arrange
+chocolatey_src = <<-PP
+  chocolateysource {'chocolatey':
+    ensure   => disabled,
+  }
+PP
+
+# teardown
+teardown do
+  reset_config
+end
+
+# act
+step 'Apply manifest'
+apply_manifest(chocolatey_src, :catch_failures => true)
+
+step 'Verify setup'
+agents.each do |agent|
+  on(agent, "cmd.exe /c \"type #{config_file_location}\"") do |result|
+    assert_match(/true/, get_xml_value("//sources/source[@id='chocolatey']/@disabled", result.output).to_s, 'Disabled did not match')
+  end
+end
+
+# act
+step 'Apply manifest a second time'
+apply_manifest(chocolatey_src, :catch_failures => true) do |result|
+  assert_not_match(/Chocolateysource\[chocolatey\]\/user\: defined 'user' as ''/, result.stdout, "User was adjusted and should not have been")
+end
+
+step 'Verify results'
+agents.each do |agent|
+  on(agent, "cmd.exe /c \"type #{config_file_location}\"") do |result|
+    assert_match(/true/, get_xml_value("//sources/source[@id='chocolatey']/@disabled", result.output).to_s, 'Disabled did not match')
+
+  end
+end
+


### PR DESCRIPTION
During the check for insync, user keeps getting detected for synchronize
due to the default value being set to '' as compared to a nil value
being returned from the existing items.

This can cause errors as it could set a source to enabled, even if the
source should be disabled. Instead we should set a default for the
existing item so it matches the default in the user property.

Still needs:
* [x] acceptance tests 
* [x] ensure when a value is changed for a disabled source that it stays disabled

Fixes for MODULES-3430 have also been included.