### PR TITLE
(MODULES-3880) Ignore Package Exit Codes

### DIFF
--- a/lib/puppet/provider/package/chocolatey.rb
+++ b/lib/puppet/provider/package/chocolatey.rb
@@ -84,11 +84,11 @@ Puppet::Type.type(:package).provide(:chocolatey, :parent => Puppet::Provider::Pa
       args << '-y'
     end
 
-    args << @resource[:install_options]
-
     if @resource[:source]
       args << '-source' << @resource[:source]
     end
+
+    args << @resource[:install_options]
 
     chocolatey(*args)
   end
@@ -106,13 +106,13 @@ Puppet::Type.type(:package).provide(:chocolatey, :parent => Puppet::Provider::Pa
       args << '-fy'
     end
 
-    args << @resource[:uninstall_options]
-
     unless choco_exe
       if @resource[:source]
         args << '-source' << @resource[:source]
       end
     end
+
+    args << @resource[:uninstall_options]
 
     chocolatey(*args)
   end
@@ -130,11 +130,11 @@ Puppet::Type.type(:package).provide(:chocolatey, :parent => Puppet::Provider::Pa
       args = 'update', @resource[:name][/\A\S*/]
     end
 
-    args << @resource[:install_options]
-
     if @resource[:source]
       args << '-source' << @resource[:source]
     end
+
+    args << @resource[:install_options]
 
     if self.query
       chocolatey(*args)

--- a/lib/puppet/provider/package/chocolatey.rb
+++ b/lib/puppet/provider/package/chocolatey.rb
@@ -106,7 +106,8 @@ Puppet::Type.type(:package).provide(:chocolatey, :parent => Puppet::Provider::Pa
       args << '-fy'
     end
 
-    unless choco_exe
+    choco_version = Gem::Version.new(PuppetX::Chocolatey::ChocolateyCommon.choco_version)
+    if !choco_exe || choco_version >= Gem::Version.new(PuppetX::Chocolatey::ChocolateyCommon::MINIMUM_SUPPORTED_CHOCO_UNINSTALL_SOURCE)
       if @resource[:source]
         args << '-source' << @resource[:source]
       end

--- a/lib/puppet/provider/package/chocolatey.rb
+++ b/lib/puppet/provider/package/chocolatey.rb
@@ -90,6 +90,10 @@ Puppet::Type.type(:package).provide(:chocolatey, :parent => Puppet::Provider::Pa
 
     args << @resource[:install_options]
 
+    if Gem::Version.new(PuppetX::Chocolatey::ChocolateyCommon.choco_version) >= Gem::Version.new(PuppetX::Chocolatey::ChocolateyCommon::MINIMUM_SUPPORTED_CHOCO_VERSION_EXIT_CODES)
+      args << '--ignore-package-exit-codes'
+    end
+
     chocolatey(*args)
   end
 
@@ -115,6 +119,10 @@ Puppet::Type.type(:package).provide(:chocolatey, :parent => Puppet::Provider::Pa
 
     args << @resource[:uninstall_options]
 
+    if Gem::Version.new(PuppetX::Chocolatey::ChocolateyCommon.choco_version) >= Gem::Version.new(PuppetX::Chocolatey::ChocolateyCommon::MINIMUM_SUPPORTED_CHOCO_VERSION_EXIT_CODES)
+      args << '--ignore-package-exit-codes'
+    end
+
     chocolatey(*args)
   end
 
@@ -136,6 +144,10 @@ Puppet::Type.type(:package).provide(:chocolatey, :parent => Puppet::Provider::Pa
     end
 
     args << @resource[:install_options]
+
+    if Gem::Version.new(PuppetX::Chocolatey::ChocolateyCommon.choco_version) >= Gem::Version.new(PuppetX::Chocolatey::ChocolateyCommon::MINIMUM_SUPPORTED_CHOCO_VERSION_EXIT_CODES)
+      args << '--ignore-package-exit-codes'
+    end
 
     if self.query
       chocolatey(*args)

--- a/lib/puppet_x/chocolatey/chocolatey_common.rb
+++ b/lib/puppet_x/chocolatey/chocolatey_common.rb
@@ -8,6 +8,7 @@ module PuppetX
 
       ## determines if C# version of choco
       FIRST_COMPILED_CHOCO_VERSION = '0.9.9.0'
+      MINIMUM_SUPPORTED_CHOCO_VERSION_EXIT_CODES = '0.9.10.0'
       MINIMUM_SUPPORTED_CHOCO_UNINSTALL_SOURCE = '0.9.10.0'
 
       def file_exists?(path)

--- a/lib/puppet_x/chocolatey/chocolatey_common.rb
+++ b/lib/puppet_x/chocolatey/chocolatey_common.rb
@@ -8,6 +8,7 @@ module PuppetX
 
       ## determines if C# version of choco
       FIRST_COMPILED_CHOCO_VERSION = '0.9.9.0'
+      MINIMUM_SUPPORTED_CHOCO_UNINSTALL_SOURCE = '0.9.10.0'
 
       def file_exists?(path)
         File.exist?(path)

--- a/spec/unit/puppet/provider/package/chocolatey_spec.rb
+++ b/spec/unit/puppet/provider/package/chocolatey_spec.rb
@@ -11,8 +11,8 @@ describe provider do
   let (:newer_choco_version) {'0.9.10.0'}
   let (:last_posh_choco_version) {'0.9.8.33'}
   let (:minimum_supported_choco_uninstall_source) {'0.9.10.0'}
+  let (:minimum_supported_choco_exit_codes) {'0.9.10.0'}
   let (:choco_zero_ten_zero) {'0.10.0'}
-
 
   before :each do
     @provider = provider.new(resource)
@@ -75,6 +75,22 @@ describe provider do
       it "should use install command without versioned package" do
         resource[:ensure] = :present
         @provider.expects(:chocolatey).with('install', 'chocolatey','-y', nil)
+
+        @provider.install
+      end
+
+      it "should call with ignore package exit codes when = 0.9.10" do
+        PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(minimum_supported_choco_exit_codes).at_least_once
+        resource[:ensure] = :present
+        @provider.expects(:chocolatey).with('install', 'chocolatey','-y', nil, '--ignore-package-exit-codes')
+
+        @provider.install
+      end
+
+      it "should call with ignore package exit codes when > 0.9.10" do
+        PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(choco_zero_ten_zero).at_least_once
+        resource[:ensure] = :present
+        @provider.expects(:chocolatey).with('install', 'chocolatey','-y', nil, '--ignore-package-exit-codes')
 
         @provider.install
       end
@@ -181,6 +197,20 @@ describe provider do
         @provider.uninstall
       end
 
+      it "should call with ignore package exit codes when = 0.9.10" do
+        PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(minimum_supported_choco_exit_codes).at_least_once
+        @provider.expects(:chocolatey).with('uninstall', 'chocolatey','-fy', nil, '--ignore-package-exit-codes')
+
+        @provider.uninstall
+      end
+
+      it "should call with ignore package exit codes when > 0.9.10" do
+        PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(choco_zero_ten_zero).at_least_once
+        @provider.expects(:chocolatey).with('uninstall', 'chocolatey','-fy', nil, '--ignore-package-exit-codes')
+
+        @provider.uninstall
+      end
+
       it "should use ignore source if it is specified and the version is less than 0.9.10" do
         resource[:source] = 'c:\packages'
         @provider.expects(:chocolatey).with('uninstall','chocolatey','-fy', nil)
@@ -191,7 +221,7 @@ describe provider do
       it "should use source if it is specified and the version is at least 0.9.10" do
         PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(minimum_supported_choco_uninstall_source).at_least_once
         resource[:source] = 'c:\packages'
-        @provider.expects(:chocolatey).with('uninstall','chocolatey', '-fy', '-source', 'c:\packages', nil)
+        @provider.expects(:chocolatey).with('uninstall','chocolatey', '-fy', '-source', 'c:\packages', nil, '--ignore-package-exit-codes')
 
         @provider.uninstall
       end
@@ -199,7 +229,7 @@ describe provider do
       it "should use source if it is specified and the version is greater than 0.9.10" do
         PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(choco_zero_ten_zero).at_least_once
         resource[:source] = 'c:\packages'
-        @provider.expects(:chocolatey).with('uninstall','chocolatey', '-fy', '-source', 'c:\packages', nil)
+        @provider.expects(:chocolatey).with('uninstall','chocolatey', '-fy', '-source', 'c:\packages', nil, '--ignore-package-exit-codes')
 
         @provider.uninstall
       end
@@ -245,6 +275,33 @@ describe provider do
 
         @provider.update
       end
+
+      it "should call with ignore package exit codes when = 0.9.10" do
+        provider.stubs(:instances).returns [provider.new({
+             :ensure   => "1.2.3",
+             :name     => "chocolatey",
+             :provider => :chocolatey,
+         })]
+        PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(minimum_supported_choco_exit_codes).at_least_once
+        resource[:ensure] = :present
+        @provider.expects(:chocolatey).with('upgrade', 'chocolatey','-y', nil, '--ignore-package-exit-codes')
+
+        @provider.update
+      end
+
+      it "should call with ignore package exit codes when > 0.9.10" do
+        provider.stubs(:instances).returns [provider.new({
+            :ensure   => "1.2.3",
+            :name     => "chocolatey",
+            :provider => :chocolatey,
+        })]
+        PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(choco_zero_ten_zero).at_least_once
+        resource[:ensure] = :present
+        @provider.expects(:chocolatey).with('upgrade', 'chocolatey','-y', nil, '--ignore-package-exit-codes')
+
+        @provider.update
+      end
+
 
       it "should use `chocolatey install` when ensure latest and package absent" do
         provider.stubs(:instances).returns []

--- a/spec/unit/puppet/provider/package/chocolatey_spec.rb
+++ b/spec/unit/puppet/provider/package/chocolatey_spec.rb
@@ -10,6 +10,9 @@ describe provider do
   let (:first_compiled_choco_version) {'0.9.9.0'}
   let (:newer_choco_version) {'0.9.10.0'}
   let (:last_posh_choco_version) {'0.9.8.33'}
+  let (:minimum_supported_choco_uninstall_source) {'0.9.10.0'}
+  let (:choco_zero_ten_zero) {'0.10.0'}
+
 
   before :each do
     @provider = provider.new(resource)
@@ -178,9 +181,25 @@ describe provider do
         @provider.uninstall
       end
 
-      it "should use ignore source if it is specified" do
+      it "should use ignore source if it is specified and the version is less than 0.9.10" do
         resource[:source] = 'c:\packages'
         @provider.expects(:chocolatey).with('uninstall','chocolatey','-fy', nil)
+
+        @provider.uninstall
+      end
+
+      it "should use source if it is specified and the version is at least 0.9.10" do
+        PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(minimum_supported_choco_uninstall_source).at_least_once
+        resource[:source] = 'c:\packages'
+        @provider.expects(:chocolatey).with('uninstall','chocolatey', '-fy', '-source', 'c:\packages', nil)
+
+        @provider.uninstall
+      end
+
+      it "should use source if it is specified and the version is greater than 0.9.10" do
+        PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(choco_zero_ten_zero).at_least_once
+        resource[:source] = 'c:\packages'
+        @provider.expects(:chocolatey).with('uninstall','chocolatey', '-fy', '-source', 'c:\packages', nil)
 
         @provider.uninstall
       end

--- a/spec/unit/puppet/provider/package/chocolatey_spec.rb
+++ b/spec/unit/puppet/provider/package/chocolatey_spec.rb
@@ -93,7 +93,7 @@ describe provider do
 
       it "should use source if it is specified" do
         resource[:source] = 'c:\packages'
-        @provider.expects(:chocolatey).with('install','chocolatey','-y', nil, '-source', 'c:\packages')
+        @provider.expects(:chocolatey).with('install','chocolatey','-y', '-source', 'c:\packages', nil)
 
         @provider.install
       end
@@ -123,7 +123,7 @@ describe provider do
 
       it "should use source if it is specified" do
         resource[:source] = 'c:\packages'
-        @provider.expects(:chocolatey).with('install','chocolatey', nil, '-source', 'c:\packages')
+        @provider.expects(:chocolatey).with('install','chocolatey', '-source', 'c:\packages', nil)
 
         @provider.install
       end
@@ -200,7 +200,7 @@ describe provider do
 
       it "should use source if it is specified" do
         resource[:source] = 'c:\packages'
-        @provider.expects(:chocolatey).with('uninstall','chocolatey', nil, '-source', 'c:\packages')
+        @provider.expects(:chocolatey).with('uninstall','chocolatey', '-source', 'c:\packages', nil)
 
         @provider.uninstall
       end
@@ -241,7 +241,7 @@ describe provider do
           :provider => :chocolatey,
         })]
         resource[:source] = 'c:\packages'
-        @provider.expects(:chocolatey).with('upgrade','chocolatey', '-y', nil, '-source', 'c:\packages')
+        @provider.expects(:chocolatey).with('upgrade','chocolatey', '-y', '-source', 'c:\packages', nil)
 
         @provider.update
       end
@@ -278,7 +278,7 @@ describe provider do
           :provider => :chocolatey,
         })]
         resource[:source] = 'c:\packages'
-        @provider.expects(:chocolatey).with('update','chocolatey', nil, '-source', 'c:\packages')
+        @provider.expects(:chocolatey).with('update','chocolatey', '-source', 'c:\packages', nil)
 
         @provider.update
       end


### PR DESCRIPTION
This might need a ticket @jpogran / @puppetlabs/windows 

A few maintenance fixes that I've been wanting to do prior to the release, the bigger of which is to add the ignore package exit codes.