### PR TITLE
(maint) Set TLS 1.1+ When Available (For Ensure Chocolatey Installation)

### DIFF
--- a/templates/InstallChocolatey.ps1.erb
+++ b/templates/InstallChocolatey.ps1.erb
@@ -38,7 +38,6 @@ $chocErrorLog = Join-Path $tempDir "chocError.log"
 # simultaneously in one FileStream and in Win32 code or another
 # FileStream."
 
-
 # This only works with the ConsoleHost (PowerShell InternalHost)
 function Fix-PowerShellOutputRedirectionBug {
   try{
@@ -57,11 +56,24 @@ function Fix-PowerShellOutputRedirectionBug {
   } catch {
     Write-Output "Unable to apply redirection fix. Error: $_"
   }
-
-
 }
 
 Fix-PowerShellOutputRedirectionBug
+
+# This should help when certain organizations have issues installing Chocolatey
+# Attempt to set highest encryption available for SecurityProtocol.
+# PowerShell will not set this by default (until maybe .NET 4.6.x). This
+# will typically produce a message for PowerShell v2 (just an info
+# message though)
+try {
+  # Set TLS 1.2 (3072), then TLS 1.1 (768), then TLS 1.0 (192), finally SSL 3.0 (48)
+  # Use integers because the enumeration values for TLS 1.2 and TLS 1.1 won't
+  # exist in .NET 4.0, even though they are addressable if .NET 4.5+ is
+  # installed (.NET 4.5 is an in-place upgrade).
+  [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192 -bor 48
+} catch {
+  Write-Output "Unable to set PowerShell to use TLS 1.2 and TLS 1.1 due to old .NET Framework installed. If you see underlying connection closed or trust errors, you may need to do one or more of the following: (1) upgrade to .NET Framework 4.5 and PowerShell v3 and/or (2) specify internal Chocolatey package location (see https://forge.puppet.com/puppetlabs/chocolatey#manage-chocolatey-installation)."
+}
 
 function Download-File {
 param (
@@ -104,7 +116,7 @@ if ($PSVersionTable.psversion.Major -gt 2) {
 } else {
   $output = Invoke-Expression $chocInstallPS1
   $output
-  write-output "Any errors that occured during install or upgrade are logged here: $chocoErrorLog"
+  Write-Output "Any errors that occured during install or upgrade are logged here: $chocoErrorLog"
   $error | out-file $chocErrorLog
 }
 


### PR DESCRIPTION
When ensuring Chocolatey's installation, attempt to set 
TLS 1.1 / TLS 1.2 when it is available and provide a message 
when it is not available. This will be helpful when attempting
to determine when an error is occurring with older 
PowerShells and .NETs in environments that have restrictions
set on TLS.