### PR TITLE
(MODULES-4135) choco -v - Remove all extraneous messaging

### DIFF
--- a/lib/puppet_x/chocolatey/chocolatey_version.rb
+++ b/lib/puppet_x/chocolatey/chocolatey_version.rb
@@ -5,13 +5,6 @@ module PuppetX
   module Chocolatey
     class ChocolateyVersion
 
-      UPGRADE_WARNING = "!!ATTENTION!!
-The next version of Chocolatey (v0.9.9) will require -y to perform
-  behaviors that change state without prompting for confirmation. Start
-  using it now in your automated scripts.
-
-  For details on the all new Chocolatey, visit http://bit.ly/new_choco
-"
       OLD_CHOCO_MESSAGE = "Please run chocolatey /? or chocolatey help - chocolatey v"
 
       def self.version
@@ -22,7 +15,11 @@ The next version of Chocolatey (v0.9.9) will require -y to perform
             # call `choco -v`
             # - new choco will output a single value e.g. `0.9.9`
             # - old choco is going to return the default output e.g. `Please run chocolatey /?`
-            version = Puppet::Util::Execution.execute("#{choco_path} -v").gsub(UPGRADE_WARNING,'').gsub(OLD_CHOCO_MESSAGE,'').strip
+            version = Puppet::Util::Execution.execute("#{choco_path} -v").gsub(OLD_CHOCO_MESSAGE,'')
+            # - other messages, such as upgrade warnings or warnings about
+            #   installing the licensed extension once the license is installed
+            #   may show up when running this comamnd. Remove those as well
+            version = version.split(/\r\n|\n|\r/).last.strip unless version.nil?
           rescue StandardError => e
             version = '0'
           end

--- a/spec/unit/puppet_x/chocolatey/chocolatey_version_spec.rb
+++ b/spec/unit/puppet_x/chocolatey/chocolatey_version_spec.rb
@@ -32,6 +32,20 @@ describe 'Chocolatey Version' do
         PuppetX::Chocolatey::ChocolateyVersion.version.must == expected_value
       end
 
+      it "should handle other messages that return with version call" do
+        expected_value = '1.2.3'
+        Puppet::Util::Execution.expects(:execute).returns("Error setting some value.\nPlease set this value yourself\r\nsound good?\r" + expected_value)
+
+        PuppetX::Chocolatey::ChocolateyVersion.version.must == expected_value
+      end
+
+      it "should handle a trailing line break" do
+        expected_value = '1.2.3'
+        Puppet::Util::Execution.expects(:execute).returns(expected_value + "\r\n")
+
+        PuppetX::Chocolatey::ChocolateyVersion.version.must == expected_value
+      end
+
       it "should handle 0.9.8.33 of choco" do
         expected_value = '1.2.3'
         Puppet::Util::Execution.expects(:execute).returns('!!ATTENTION!!


### PR DESCRIPTION
When determining the version of Chocolatey that is installed, the
module calls `choco -v` which will return the version in most versions
of Chocolatey (anything earlier than 0.9.8.24 or more than 4 years old
may not). However sometimes there is messaging that tends to be
presented as warnings that still end up being included in the output.
Instead of looking for specific wording, typically the chocolatey
version is going to be the last line in the output. So remove all of
the other lines and just use the last line available.

Using a simpler `string.lines.last` is out because it only splits
on `$/` and doesn't allow multiple options. So split on CRLF, then LF,
then CR. This allows the output to be evaluated on different
platforms and not be subject to whatever Ruby believes `$/` evaluates
to on that platform.