### PR TITLE
(MODULES-4091) Explicitly Set ChocolateyInstall Environment

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,5 +2,6 @@ fixtures:
   forge_modules:
     stdlib:       "puppetlabs/stdlib"
     powershell:   "puppetlabs/powershell"
+    registry:     "puppetlabs/registry"
   symlinks:
     chocolatey: "#{source_dir}"

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -9,8 +9,13 @@ class chocolatey::config {
   # user may link to - it could be an older version of
   # Chocolatey
 
+  $_choco_version = $chocolatey::chocolatey_version ? {
+    undef   => '0',
+    default => $chocolatey::chocolatey_version
+  }
+
 # lint:ignore:80chars
-  if versioncmp($chocolatey::chocolatey_version, '0.9.9.0') >= 0 and versioncmp($chocolatey::chocolatey_version, '0.9.10.0') < 0 {
+  if versioncmp($_choco_version, '0.9.9.0') >= 0 and versioncmp($_choco_version, '0.9.10.0') < 0 {
     $_choco_exe_path = "${chocolatey::choco_install_location}\\bin\\choco.exe"
 
     $_enable_autouninstaller = $chocolatey::enable_autouninstaller ? {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -8,12 +8,20 @@ class chocolatey::install {
     default   => 'windows'
   }
 
+  registry_value { 'ChocolateyInstall environment value':
+    ensure => present,
+    path   => 'HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\ChocolateyInstall',
+    type   => 'string',
+    data   => $chocolatey::choco_install_location,
+  }
+
   exec { 'install_chocolatey_official':
     command     => template('chocolatey/InstallChocolatey.ps1.erb'),
     creates     => "${::chocolatey::choco_install_location}\\bin\\choco.exe",
     provider    => powershell,
     timeout     => $::chocolatey::choco_install_timeout_seconds,
     logoutput   => $::chocolatey::log_output,
-    environment => ["ChocolateyInstall=${::chocolatey::choco_install_location}"]
+    environment => ["ChocolateyInstall=${::chocolatey::choco_install_location}"],
+    require     => Registry_value['ChocolateyInstall environment value'],
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -52,6 +52,10 @@
     {
       "name": "puppetlabs/powershell",
       "version_requirement": ">= 1.0.1 < 3.0.0"
+    },
+    {
+      "name": "puppetlabs/registry",
+      "version_requirement": ">= 1.0.0 < 3.0.0"
     }
   ]
 }


### PR DESCRIPTION
Previously, ensuring the installation directory for Chocolatey
keyed off of an environment value passed to an exec powershell
resource through the environment parameter. However there is a
bug in the powershell module in versions 2.x up to 2.1.0
(current version as of this commit) that ignore the environment
parameter. Since it is better to explicitly set that value, take
a dependency on the registry module and explicitly ensure the
environment variable is set so that Chocolatey will successfully
install to an alternative install location.