### PR TITLE
(MODULES-4149) Unsuitable providers should not error

### DIFF
--- a/lib/puppet/provider/chocolateyconfig/windows.rb
+++ b/lib/puppet/provider/chocolateyconfig/windows.rb
@@ -100,7 +100,7 @@ Puppet::Type.type(:chocolateyconfig).provide(:windows) do
 
   def validate
     choco_version = Gem::Version.new(PuppetX::Chocolatey::ChocolateyCommon.choco_version)
-    if choco_version < Gem::Version.new(CONFIG_MINIMUM_SUPPORTED_CHOCO_VERSION)
+    if PuppetX::Chocolatey::ChocolateyCommon.file_exists?(PuppetX::Chocolatey::ChocolateyCommon.chocolatey_command) && choco_version < Gem::Version.new(CONFIG_MINIMUM_SUPPORTED_CHOCO_VERSION)
       raise Puppet::ResourceError, "Chocolatey version must be '#{CONFIG_MINIMUM_SUPPORTED_CHOCO_VERSION}' to manage configuration values. Detected '#{choco_version}' as your version. Please upgrade Chocolatey."
     end
   end

--- a/lib/puppet/provider/chocolateyfeature/windows.rb
+++ b/lib/puppet/provider/chocolateyfeature/windows.rb
@@ -97,7 +97,7 @@ Puppet::Type.type(:chocolateyfeature).provide(:windows) do
 
   def validate
     choco_version = Gem::Version.new(PuppetX::Chocolatey::ChocolateyCommon.choco_version)
-    if choco_version < Gem::Version.new(FEATURE_MINIMUM_SUPPORTED_CHOCO_VERSION)
+    if PuppetX::Chocolatey::ChocolateyCommon.file_exists?(PuppetX::Chocolatey::ChocolateyCommon.chocolatey_command) && choco_version < Gem::Version.new(FEATURE_MINIMUM_SUPPORTED_CHOCO_VERSION)
       raise Puppet::ResourceError, "Chocolatey version must be '#{FEATURE_MINIMUM_SUPPORTED_CHOCO_VERSION}' to manage configuration values with Puppet. Detected '#{choco_version}' as your version. Please upgrade Chocolatey to use this resource."
     end
   end

--- a/lib/puppet/provider/chocolateysource/windows.rb
+++ b/lib/puppet/provider/chocolateysource/windows.rb
@@ -113,7 +113,7 @@ Puppet::Type.type(:chocolateysource).provide(:windows) do
 
   def validate
     choco_version = Gem::Version.new(PuppetX::Chocolatey::ChocolateyCommon.choco_version)
-    if choco_version < Gem::Version.new(MINIMUM_SUPPORTED_CHOCO_VERSION)
+    if PuppetX::Chocolatey::ChocolateyCommon.file_exists?(PuppetX::Chocolatey::ChocolateyCommon.chocolatey_command) && choco_version < Gem::Version.new(MINIMUM_SUPPORTED_CHOCO_VERSION)
       raise Puppet::ResourceError, "Chocolatey version must be '#{MINIMUM_SUPPORTED_CHOCO_VERSION}' to manage configuration values with Puppet. Detected '#{choco_version}' as your version. Please upgrade Chocolatey to use this resource."
     end
 

--- a/spec/unit/puppet/provider/chocolateyfeature/windows_spec.rb
+++ b/spec/unit/puppet/provider/chocolateyfeature/windows_spec.rb
@@ -9,6 +9,7 @@ describe provider do
   let (:name) { 'allowglobalconfirmation' }
   let (:resource) { Puppet::Type.type(:chocolateyfeature).new(:provider => :windows, :name => name, :ensure => 'enabled' ) }
   let (:choco_config) { 'c:\choco.config' }
+  let (:choco_install_path) { 'c:\dude\bin\choco.exe' }
   let (:choco_config_contents) { <<-'EOT'
 <?xml version="1.0" encoding="utf-8"?>
 <chocolatey xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -56,6 +57,7 @@ describe provider do
   let (:minimum_supported_version) {'0.9.9.0'}
 
   before :each do
+    PuppetX::Chocolatey::ChocolateyInstall.stubs(:install_path).returns('c:\dude')
     PuppetX::Chocolatey::ChocolateyCommon.stubs(:choco_version).returns(minimum_supported_version)
 
     @provider = provider.new(resource)

--- a/spec/unit/puppet/provider/chocolateysource/windows_spec.rb
+++ b/spec/unit/puppet/provider/chocolateysource/windows_spec.rb
@@ -10,6 +10,7 @@ describe provider do
   let (:location) { 'c:\packages' }
   let (:resource) { Puppet::Type.type(:chocolateysource).new(:provider => :windows, :name => name, :location => location) }
   let (:choco_config) { 'c:\choco.config' }
+  let (:choco_install_path) { 'c:\dude\bin\choco.exe' }
   let (:choco_config_contents) { <<-'EOT'
 <?xml version="1.0" encoding="utf-8"?>
 <chocolatey xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -61,6 +62,7 @@ describe provider do
   let (:last_unsupported_version) {'0.9.8.33'}
 
   before :each do
+    PuppetX::Chocolatey::ChocolateyInstall.stubs(:install_path).returns('c:\dude')
     PuppetX::Chocolatey::ChocolateyCommon.stubs(:choco_version).returns(minimum_supported_version)
 
     @provider = provider.new(resource)
@@ -243,6 +245,11 @@ describe provider do
   end
 
   context ".validation" do
+    before :each do
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:file_exists?).returns(true).at_least(0)
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:file_exists?).with(choco_install_path).returns(true).at_least(0)
+    end
+
     it "should not warn when both user/password are empty" do
       PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(minimum_supported_version)
       Puppet.expects(:warning).never


### PR DESCRIPTION
When attempting to force the provider, validation would error due
to the version coming back would not be above the version that is
being validated. When the provider is unsuitable, it should not
return an error during the Puppet run and should instead just
return the unsuitable message.

Check to ensure Chocolatey is installed prior to allowing the
validation check to not fail the Puppet run.