### PR TITLE
(MODULES-4210) Do not use com unzip in PS 5+

### DIFF
--- a/templates/InstallChocolatey.ps1.erb
+++ b/templates/InstallChocolatey.ps1.erb
@@ -100,10 +100,14 @@ if ($unzipMethod -eq '7zip') {
   Write-Output "Extracting $file to $tempDir..."
   Start-Process "$7zaExe" -ArgumentList "x -o`"$tempDir`" -y `"$file`"" -Wait -NoNewWindow
 } else {
-  $shellApplication = new-object -com shell.application
-  $zipPackage = $shellApplication.NameSpace($file)
-  $destinationFolder = $shellApplication.NameSpace($tempDir)
-  $destinationFolder.CopyHere($zipPackage.Items(),0x10)
+  if ($PSVersionTable.PSversion.major -lt 5) {
+    $shellApplication = new-object -com shell.application
+    $zipPackage = $shellApplication.NameSpace($file)
+    $destinationFolder = $shellApplication.NameSpace($tempDir)
+    $destinationFolder.CopyHere($zipPackage.Items(),0x10)
+  } else {
+    Expand-Archive -Path "$file" -DestinationPath "$tempDir" -Force
+  }
 }
 
 # call chocolatey install


### PR DESCRIPTION
At least in Windows 10, the use of COM objects for unizp does not seem
to work in a non-interactive session