### PR TITLE
(MODULES-4056) Helpful Error if No Sources Enabled

### DIFF
--- a/lib/puppet/provider/package/chocolatey.rb
+++ b/lib/puppet/provider/package/chocolatey.rb
@@ -199,6 +199,7 @@ Puppet::Type.type(:package).provide(:chocolatey, :parent => Puppet::Provider::Pa
         process.each_line do |line|
           line.chomp!
           if line.empty? or line.match(/Reading environment variables.*/); next; end
+          raise Puppet::Error, "At least one source must be enabled." if line.match(/Unable to search for packages.*/)
           if choco_exe
             values = line.split('|')
           else

--- a/spec/unit/puppet/provider/package/chocolatey_spec.rb
+++ b/spec/unit/puppet/provider/package/chocolatey_spec.rb
@@ -473,6 +473,14 @@ describe provider do
               :name => 'package2'
           }
         end
+
+        it "should return nil on error" do
+          provider.expects(:execpipe).yields(StringIO.new(%Q(Unable to search for packages when there are no soures enabled for packages and none were passed as arguments.\n)))
+
+          expect {
+            provider.instances
+          }.to raise_error(Puppet::Error, /At least one source must be enabled./)
+        end
       end
 
       context "with posh choco client" do


### PR DESCRIPTION
Previously, when there were no sources enabled, Puppet would
attempt to loop over a non-existent set of packages pulled back
from listing a set of packages locally. Unfortunately this is due
to an issue in Chocolatey that requires at least one source to be
enabled to produce the local set of installed packages:
https://github.com/chocolatey/choco/issues/661

Instead of allowing Puppet to fail on a nil:NilClass error, provide
a helpful and actionable message instead.