### PR TITLE
(maint) Fix parallel spec issue with coverage_spec

### DIFF
--- a/spec/classes/coverage_spec.rb
+++ b/spec/classes/coverage_spec.rb
@@ -1,1 +1,3 @@
+require 'spec_helper'
+
 at_exit { RSpec::Puppet::Coverage.report! }


### PR DESCRIPTION
Previously, the specs were run in serial, or in larger chunks in parallel.
Unfortunately this hides errors where spec files don't explicitly load all
requires before loading.  This commit adds the require spec_helper to any
remaining spec files so that parallel spec can complete correctly.