### PR TITLE
(Modules-4508) Fixed error with version parameter

### DIFF
--- a/lib/puppet/provider/package/chocolatey.rb
+++ b/lib/puppet/provider/package/chocolatey.rb
@@ -77,7 +77,7 @@ Puppet::Type.type(:package).provide(:chocolatey, :parent => Puppet::Provider::Pa
       end
 
       # Add the package version
-      args << @resource[:name][/\A\S*/] << '-version' << @resource[:ensure]
+      args << @resource[:name][/\A\S*/] << '--version' << @resource[:ensure]
     end
 
     if choco_exe

--- a/spec/unit/puppet/provider/package/chocolatey_spec.rb
+++ b/spec/unit/puppet/provider/package/chocolatey_spec.rb
@@ -97,7 +97,7 @@ describe provider do
 
       it "should use upgrade command with versioned package" do
         resource[:ensure] = '1.2.3'
-        @provider.expects(:chocolatey).with('upgrade', 'chocolatey', '-version', '1.2.3', '-y', nil)
+        @provider.expects(:chocolatey).with('upgrade', 'chocolatey', '--version', '1.2.3', '-y', nil)
 
         @provider.install
       end
@@ -135,7 +135,7 @@ describe provider do
 
       it "should use update command with versioned package" do
         resource[:ensure] = '1.2.3'
-        @provider.expects(:chocolatey).with('update', 'chocolatey', '-version', '1.2.3', nil)
+        @provider.expects(:chocolatey).with('update', 'chocolatey', '--version', '1.2.3', nil)
 
         @provider.install
       end


### PR DESCRIPTION
Using one dash instead of two for a parameter causes chocolatey to think
the parameter is a bundled option (like -dvyf means --debug --verbose
--confirm --force).