### PR TITLE
(MODULES-4601) Fail rototiller task correctly.

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -29,6 +29,9 @@ Gemfile:
     ':system_tests':
       - gem: beaker-windows
         version: '~> 0.6'
+    ':development':
+      - gem: rototiller
+        version: '~> 1.0'
 Rakefile:
   unmanaged: true
 spec/spec_helper.rb:

--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ group :development do
   gem 'fast_gettext', '1.1.0',              :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')
   gem 'fast_gettext',                       :require => false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
   gem 'rainbow', '< 2.2.0',                 :require => false
+  gem 'rototiller', '~> 1.0',               :require => false
 end
 
 group :system_tests do

--- a/Rakefile
+++ b/Rakefile
@@ -166,6 +166,8 @@ begin
       end
     end
   end
-rescue LoadError
-  #Do nothing, rototiller only installed with system_tests group
+rescue LoadError => e
+  STDERR.puts "Unable to load rototiller:"
+  raise e
 end
+


### PR DESCRIPTION
Re-added the rototiller gem to .sync and Gemfile; set minimum version to 1.0.

Added a fail condition if a rototiller command is called without the gem present so we don't see this happen silently again.

Moved rototiller gem to Development group.