### PR TITLE
(MODULES-4678) Explicitly close config on read

### DIFF
--- a/lib/puppet/provider/chocolateyconfig/windows.rb
+++ b/lib/puppet/provider/chocolateyconfig/windows.rb
@@ -42,7 +42,7 @@ Puppet::Type.type(:chocolateyconfig).provide(:windows) do
     raise Puppet::ResourceError, "An install was detected, but was unable to locate config file at #{choco_config}." unless PuppetX::Chocolatey::ChocolateyCommon.file_exists?(choco_config)
 
     Puppet.debug("Gathering sources from '#{choco_config}'.")
-    config = REXML::Document.new File.new(choco_config, 'r')
+    config = REXML::Document.new File.read(choco_config)
 
     config.elements.to_a( '//add' )
   end

--- a/lib/puppet/provider/chocolateyfeature/windows.rb
+++ b/lib/puppet/provider/chocolateyfeature/windows.rb
@@ -41,7 +41,7 @@ Puppet::Type.type(:chocolateyfeature).provide(:windows) do
     raise Puppet::ResourceError, "An install was detected, but was unable to locate config file at #{choco_config}." unless PuppetX::Chocolatey::ChocolateyCommon.file_exists?(choco_config)
 
     Puppet.debug("Gathering features from '#{choco_config}'.")
-    config = REXML::Document.new File.new(choco_config, 'r')
+    config = REXML::Document.new File.read(choco_config)
 
     config.elements.to_a( '//feature' )
   end

--- a/lib/puppet/provider/chocolateysource/windows.rb
+++ b/lib/puppet/provider/chocolateysource/windows.rb
@@ -43,7 +43,7 @@ Puppet::Type.type(:chocolateysource).provide(:windows) do
     raise Puppet::ResourceError, "An install was detected, but was unable to locate config file at #{choco_config}." unless PuppetX::Chocolatey::ChocolateyCommon.file_exists?(choco_config)
 
     Puppet.debug("Gathering sources from '#{choco_config}'.")
-    config = REXML::Document.new File.new(choco_config, 'r')
+    config = REXML::Document.new File.read(choco_config)
 
     config.elements.to_a( '//source' )
   end

--- a/spec/unit/puppet/provider/chocolateyconfig/windows_spec.rb
+++ b/spec/unit/puppet/provider/chocolateyconfig/windows_spec.rb
@@ -143,7 +143,7 @@ describe provider do
       before :each do
         PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_config_file).returns(choco_config)
         PuppetX::Chocolatey::ChocolateyCommon.expects(:file_exists?).with(choco_config).returns(true)
-        File.expects(:new).with(choco_config,"r").returns choco_config_contents
+        File.expects(:read).with(choco_config).returns choco_config_contents
 
         configs = provider.get_configs
       end
@@ -222,7 +222,7 @@ describe provider do
       PuppetX::Chocolatey::ChocolateyCommon.expects(:set_env_chocolateyinstall).at_most_once
       PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_config_file).returns(choco_config).at_most_once
       PuppetX::Chocolatey::ChocolateyCommon.expects(:file_exists?).with(choco_config).returns(true).at_most_once
-      File.expects(:new).with(choco_config,"r").returns(choco_config_contents).at_most_once
+      File.expects(:read).with(choco_config).returns(choco_config_contents).at_most_once
 
       resource[:name] = resource_name
       resource[:value] = resource_value

--- a/spec/unit/puppet/provider/chocolateyfeature/windows_spec.rb
+++ b/spec/unit/puppet/provider/chocolateyfeature/windows_spec.rb
@@ -122,7 +122,7 @@ describe provider do
       before :each do
         PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_config_file).returns(choco_config)
         PuppetX::Chocolatey::ChocolateyCommon.expects(:file_exists?).with(choco_config).returns(true)
-        File.expects(:new).with(choco_config,"r").returns choco_config_contents
+        File.expects(:read).with(choco_config).returns choco_config_contents
 
         features = provider.get_features
       end

--- a/spec/unit/puppet/provider/chocolateysource/windows_spec.rb
+++ b/spec/unit/puppet/provider/chocolateysource/windows_spec.rb
@@ -172,7 +172,7 @@ describe provider do
       before :each do
         PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_config_file).returns(choco_config)
         PuppetX::Chocolatey::ChocolateyCommon.expects(:file_exists?).with(choco_config).returns(true)
-        File.expects(:new).with(choco_config,"r").returns choco_config_contents
+        File.expects(:read).with(choco_config).returns choco_config_contents
 
         sources = provider.get_sources
       end
@@ -379,7 +379,7 @@ describe provider do
       PuppetX::Chocolatey::ChocolateyCommon.expects(:set_env_chocolateyinstall).at_most_once
       PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_config_file).returns(choco_config).at_most_once
       PuppetX::Chocolatey::ChocolateyCommon.expects(:file_exists?).with(choco_config).returns(true).at_most_once
-      File.expects(:new).with(choco_config,"r").returns(choco_config_contents).at_most_once
+      File.expects(:read).with(choco_config).returns(choco_config_contents).at_most_once
 
       resource[:name] = resource_name
       resource[:location] = resource_location


### PR DESCRIPTION
Previously, any providers managing Chocolatey configuration are unable
to be used with 0.10.4+ and actually cause the process to
fail.

Chocolatey 0.10.4+ has changed the way it updates and accesses the
config. The new method has exposed an error in an unclosed file handle
when reading the configuration for `chocolateysource`,
`chocolateyfeature`, and `chocolateyconfig`. Switch to `File.read` as
it will automatically close the file after reading out the contents.