### PR TITLE
(MODULES-5187)(MODULES-5356) Pin rspec-puppet to 2.5.x

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -41,9 +41,6 @@ Rakefile:
   unmanaged: true
 spec/spec_helper.rb:
   unmanaged: true
-appveyor.yml:
-  test_script:
-    - 'bundle exec rspec spec/unit -fd -b'
 MAINTAINERS.md:
   maintainers:
     - "Puppet Windows Team `windows |at| puppet |dot| com`"

--- a/.sync.yml
+++ b/.sync.yml
@@ -37,6 +37,10 @@ Gemfile:
     ':development':
       - gem: rototiller
         version: '~> 1.0'
+      # rspec-puppet is pinned to < 2.6.0 due to https://github.com/rodjek/rspec-puppet/issues/577
+      - gem: 'rspec-puppet'
+        platforms: ["mswin", "mingw", "x64_mingw"]
+        version: '< 2.6.0'
 Rakefile:
   unmanaged: true
 spec/spec_helper.rb:

--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ group :development do
   gem "fast_gettext", '1.1.0',                            :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')
   gem "fast_gettext",                                     :require => false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
   gem "rototiller", '~> 1.0',                             :require => false
+  gem "rspec-puppet", '< 2.6.0',                          :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
 end
 
 group :system_tests do

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,7 +42,7 @@ build: off
 test_script:
 - bundle exec puppet -V
 - ruby -v
-- bundle exec rspec spec/unit -fd -b
+- bundle exec rake spec SPEC_OPTS='--format documentation'
 notifications:
 - provider: Email
   to:

--- a/spec/unit/puppet/provider/package/chocolatey_spec.rb
+++ b/spec/unit/puppet/provider/package/chocolatey_spec.rb
@@ -426,14 +426,7 @@ describe provider do
   end
 
   context "when fetching a package list" do
-    # Due to PUP-7772 should only test this on Windows.  Once this issue is resolved
-    # the confinements could be removed.
-    it "should invoke provider listcmd (Puppet 5.0 on Windows)", :if => Puppet::Util::Platform.windows? && Puppet.version == '5.0.0' do
-      provider.expects(:listcmd).returns('cmd /c exit 0')
-
-      provider.instances
-    end
-    it "should invoke provider listcmd (Puppet 4.x)", :if => /^4\./ =~ Puppet.version do
+    it "should invoke provider listcmd" do
       provider.expects(:listcmd)
 
       provider.instances


### PR DESCRIPTION
This commit pins rspec-puppet to '< 2.6.0' due to a bug in rspec-puppet
(rodjek/rspec-puppet#577)