### PR TITLE
(MODULES-5383) Remove exit codes arg with feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Fixed
 
 - Ensure the `source` syntax in the provider is correct ([MODULES-8493](https://tickets.puppetlabs.com/browse/MODULES-8493)). Thanks, [@jcwest](https://github.com/jcwest)!
+- Ensure that if `usePackageExitCodes` is explicitly set to `true` in the Chocolatey configuration then it is observed ([MODULES-8353](https://tickets.puppetlabs.com/browse/MODULES-8353)). Thanks, [David Wood](https://github.com/davidtwco)!
 
 ## [3.1.1] - 2018-12-10
 

--- a/README.md
+++ b/README.md
@@ -269,6 +269,9 @@ non-zero (this value can come from a dependency package). Chocolatey
 defines valid exit codes as 0, 1605, 1614, 1641, 3010. With this feature
 disabled, Chocolatey exits with a 0 or a 1 (matching previous behavior).
 
+Note that this behavior _may_ cause Puppet to think that the run has failed.
+We advise that you leave this at the default setting or explicitly disable it but that you do _not_ explicitly enable it.
+
 ~~~puppet
 chocolateyfeature {'usepackageexitcodes':
   ensure => disabled,

--- a/lib/puppet/provider/package/chocolatey.rb
+++ b/lib/puppet/provider/package/chocolatey.rb
@@ -51,6 +51,25 @@ Puppet::Type.type(:package).provide(:chocolatey, :parent => Puppet::Provider::Pa
     self.class.is_compiled_choco?
   end
 
+  def is_usepackageexitcodes_feature_enabled?
+    PuppetX::Chocolatey::ChocolateyCommon.set_env_chocolateyinstall
+
+    choco_config = PuppetX::Chocolatey::ChocolateyCommon.choco_config_file
+    raise Puppet::ResourceError, "Config file not found for Chocolatey. Please make sure you have Chocolatey installed." if choco_config.nil?
+    raise Puppet::ResourceError, "An install was detected, but was unable to locate config file at #{choco_config}." unless PuppetX::Chocolatey::ChocolateyCommon.file_exists?(choco_config)
+
+    config = REXML::Document.new File.read(choco_config)
+    feature_tags = config.elements.to_a('//feature').select do |feature|
+      feature.attributes['name'].downcase == 'usepackageexitcodes'
+    end
+
+    return false if feature_tags.empty?
+    feature = feature_tags.first
+
+    return true if feature.attributes['enabled'].downcase == 'true'
+    false
+  end
+
   def install
     PuppetX::Chocolatey::ChocolateyCommon.set_env_chocolateyinstall
      choco_exe = is_compiled_choco?
@@ -90,7 +109,8 @@ Puppet::Type.type(:package).provide(:chocolatey, :parent => Puppet::Provider::Pa
 
     args << @resource[:install_options]
 
-    if Gem::Version.new(PuppetX::Chocolatey::ChocolateyCommon.choco_version) >= Gem::Version.new(PuppetX::Chocolatey::ChocolateyCommon::MINIMUM_SUPPORTED_CHOCO_VERSION_EXIT_CODES)
+    if Gem::Version.new(PuppetX::Chocolatey::ChocolateyCommon.choco_version) >= Gem::Version.new(PuppetX::Chocolatey::ChocolateyCommon::MINIMUM_SUPPORTED_CHOCO_VERSION_EXIT_CODES) and
+        not is_usepackageexitcodes_feature_enabled?
       args << '--ignore-package-exit-codes'
     end
 
@@ -119,7 +139,8 @@ Puppet::Type.type(:package).provide(:chocolatey, :parent => Puppet::Provider::Pa
 
     args << @resource[:uninstall_options]
 
-    if Gem::Version.new(PuppetX::Chocolatey::ChocolateyCommon.choco_version) >= Gem::Version.new(PuppetX::Chocolatey::ChocolateyCommon::MINIMUM_SUPPORTED_CHOCO_VERSION_EXIT_CODES)
+    if Gem::Version.new(PuppetX::Chocolatey::ChocolateyCommon.choco_version) >= Gem::Version.new(PuppetX::Chocolatey::ChocolateyCommon::MINIMUM_SUPPORTED_CHOCO_VERSION_EXIT_CODES) and
+        not is_usepackageexitcodes_feature_enabled?
       args << '--ignore-package-exit-codes'
     end
 
@@ -145,7 +166,8 @@ Puppet::Type.type(:package).provide(:chocolatey, :parent => Puppet::Provider::Pa
 
     args << @resource[:install_options]
 
-    if Gem::Version.new(PuppetX::Chocolatey::ChocolateyCommon.choco_version) >= Gem::Version.new(PuppetX::Chocolatey::ChocolateyCommon::MINIMUM_SUPPORTED_CHOCO_VERSION_EXIT_CODES)
+    if Gem::Version.new(PuppetX::Chocolatey::ChocolateyCommon.choco_version) >= Gem::Version.new(PuppetX::Chocolatey::ChocolateyCommon::MINIMUM_SUPPORTED_CHOCO_VERSION_EXIT_CODES) and
+        not is_usepackageexitcodes_feature_enabled?
       args << '--ignore-package-exit-codes'
     end
 

--- a/spec/unit/puppet/provider/package/chocolatey_spec.rb
+++ b/spec/unit/puppet/provider/package/chocolatey_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 require 'stringio'
 require 'puppet/type/package'
 require 'puppet/provider/package/chocolatey'
+require 'rexml/document'
 
 provider = Puppet::Type.type(:package).provider(:chocolatey)
 
@@ -13,6 +14,60 @@ describe provider do
   let (:minimum_supported_choco_uninstall_source) {'0.9.10.0'}
   let (:minimum_supported_choco_exit_codes) {'0.9.10.0'}
   let (:choco_zero_ten_zero) {'0.10.0'}
+  let (:choco_config) { 'c:\choco.config' }
+  let (:choco_install_path) { 'c:\dude\bin\choco.exe' }
+  let (:choco_config_contents) { <<-'EOT'
+<?xml version="1.0" encoding="utf-8"?>
+<chocolatey xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <config>
+    <add key="cacheLocation" value="" description="Cache location if not TEMP folder." />
+    <add key="commandExecutionTimeoutSeconds" value="2700" description="Default timeout for command execution." />
+    <add key="containsLegacyPackageInstalls" value="true" description="Install has packages installed prior to 0.9.9 series." />
+    <add key="proxy" value="" description="Explicit proxy location." />
+    <add key="proxyUser" value="" description="Optional proxy user." />
+    <add key="proxyPassword" value="" description="Optional proxy password. Encrypted." />
+    <add key="virusCheckMinimumPositives" value="5" description="Minimum numer of scan result positives before flagging a binary as a possible virus. Available in 0.9.10+. Licensed versions only." />
+    <add key="virusScannerType" value="VirusTotal" description="Virus Scanner Type (Generic or VirusTotal). Defaults to VirusTotal for Pro. Available in 0.9.10+. Licensed versions only." />
+    <add key="genericVirusScannerPath" value="" description="The full path to the command line virus scanner executable. Used when virusScannerType is Generic. Available in 0.9.10+. Licensed versions only." />
+    <add key="genericVirusScannerArgs" value="[[File]]" description="The arguments to pass to the generic virus scanner. Use [[File]] for the file path placeholder. Used when virusScannerType is Generic. Available in 0.9.10+. Licensed versions only." />
+    <add key="genericVirusScannerValidExitCodes" value="0" description="The exit codes for the generic virus scanner when a file is not flagged. Separate with comma, defaults to 0. Used when virusScannerType is Generic. Available in 0.9.10+. Licensed versions only." />
+  </config>
+  <sources>
+    <source id="local" value="c:\packages" disabled="true" user="rob" password="bogus/encrypted+value=" priority="0" />
+    <source id="chocolatey" value="https://chocolatey.org/api/v2/" disabled="false" priority="0" />
+    <source id="chocolatey.licensed" value="https://licensedpackages.chocolatey.org/api/v2/" disabled="false" user="customer" password="bogus/encrypted+value=" priority="10" />
+  </sources>
+  <features>
+    <feature name="checksumFiles" enabled="true" setExplicitly="false" description="Checksum files when pulled in from internet (based on package)." />
+    <feature name="virusCheckFiles" enabled="false" setExplicitly="false" />
+    <feature name="autoUninstaller" enabled="true" setExplicitly="true" description="Uninstall from programs and features without requiring an explicit uninstall script." />
+    <feature name="allowGlobalConfirmation" enabled="false" setExplicitly="true" description="Prompt for confirmation in scripts or bypass." />
+    <feature name="allowInsecureConfirmation" enabled="false" setExplicitly="false" />
+    <feature name="failOnAutoUninstaller" enabled="false" setExplicitly="false" description="Fail if automatic uninstaller fails." />
+    <feature name="failOnStandardError" enabled="false" setExplicitly="false" description="Fail if install provider writes to stderr." />
+    <feature name="powershellHost" enabled="true" setExplicitly="false" description="Use Chocolatey''s built-in PowerShell host." />
+    <feature name="logEnvironmentValues" enabled="false" setExplicitly="false" description="Log Environment Values - will log values of environment before and after install (could disclose sensitive data)." />
+    <feature name="virusCheck" enabled="true" setExplicitly="true" description="Virus Check - perform virus checking on downloaded files. Available in 0.9.10+. Licensed versions only." />
+    <feature name="downloadCache" enabled="true" setExplicitly="false" description="Download Cache - use the private download cache if available for a package. Available in 0.9.10+. Licensed versions only." />
+    <feature name="failOnInvalidOrMissingLicense" enabled="false" setExplicitly="false" description="Fail On Invalid Or Missing License - allows knowing when a license is expired or not applied to a machine." />
+    <feature name="ignoreInvalidOptionsSwitches" enabled="true" setExplicitly="false" description="Ignore Invalid Options/Switches - If a switch or option is passed that is not recognized, should choco fail?" />
+    <feature name="usePackageExitCodes" enabled="true" setExplicitly="false" description="Use Package Exit Codes - Package scripts can provide exit codes. With this on, package exit codes will be what choco uses for exit when non-zero (this value can come from a dependency package). Chocolatey defines valid exit codes as 0, 1605, 1614, 1641, 3010. With this feature off, choco will exit with a 0 or a 1 (matching previous behavior). Available in 0.9.10+." />
+  </features>
+  <apiKeys>
+    <apiKeys source="https://chocolatey.org/" key="bogus/encrypted+value=" />
+ </apiKeys>
+</chocolatey>
+  EOT
+  }
+  let (:choco_config_contents_upec) { <<-'EOT'
+    <?xml version="1.0" encoding="utf-8"?>
+    <chocolatey xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <features>
+        <feature name="usePackageExitCodes" enabled="true" setExplicitly="true" description="Use Package Exit Codes - Package scripts can provide exit codes. With this on, package exit codes will be what choco uses for exit when non-zero (this value can come from a dependency package). Chocolatey defines valid exit codes as 0, 1605, 1614, 1641, 3010. With this feature off, choco will exit with a 0 or a 1 (matching previous behavior). Available in 0.9.10+." />
+      </features>
+    </chocolatey>
+  EOT
+  }
 
   before :each do
     @provider = provider.new(resource)
@@ -61,13 +116,101 @@ describe provider do
     end
   end
 
+  context "self.get_choco_features" do
+    before :each do
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:set_env_chocolateyinstall)
+    end
+
+    it "should error when the config file location is null" do
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_config_file).returns(nil)
+
+      expect {
+        @provider.get_choco_features
+      }.to raise_error(Puppet::ResourceError, /Config file not found for Chocolatey/)
+    end
+
+    it "should error when the config file is not found" do
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_config_file).returns(choco_config)
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:file_exists?).with(choco_config).returns(false)
+
+      expect {
+        @provider.get_choco_features
+      }.to raise_error(Puppet::ResourceError, /was unable to locate config file at/)
+    end
+
+    context "when getting sources from the config file" do
+      choco_features = []
+
+      before :each do
+        PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_config_file).returns(choco_config)
+        PuppetX::Chocolatey::ChocolateyCommon.expects(:file_exists?).with(choco_config).returns(true)
+        File.expects(:read).with(choco_config).returns choco_config_contents
+
+        choco_features = @provider.get_choco_features
+      end
+
+      it "should match the count of sources in the config" do
+        choco_features.count.must eq 14
+      end
+
+      it "should contain xml elements" do
+        choco_features[0].must be_an_instance_of REXML::Element
+      end
+    end
+  end
+
+  context "self.get_choco_feature" do
+    let (:element) {  REXML::Element.new('source') }
+    element_name           = "default"
+    element_enabled        = "true"
+    element_set_explicitly = "false"
+    element_description    = "10"
+
+    before :each do
+      element.add_attributes( { "name"          => element_name,
+                                "enabled"       => element_enabled,
+                                "setExplicitly" => element_set_explicitly,
+                                "description"   => element_description,
+                              } )
+    end
+
+    it "should return nil source when element is nil" do
+      @provider.get_choco_feature(nil).must be == {}
+    end
+
+    it "should convert an element to a source" do
+      choco_feature = @provider.get_choco_feature(element)
+
+      choco_feature[:name].must eq element_name
+      choco_feature[:enabled].must eq element_enabled
+      choco_feature[:set_explicitly].must eq element_set_explicitly
+      choco_feature[:description].must eq element_description
+    end
+  end
+
+  context "self.choco_features" do
+    before :each do
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:set_env_chocolateyinstall)
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_config_file).returns(choco_config)
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:file_exists?).with(choco_config).returns(true)
+      File.expects(:read).with(choco_config).returns choco_config_contents
+      herp = @provider.choco_features
+    end
+
+    it "should return an array of hashes" do
+      @provider.choco_features.count.must eq 14
+      @provider.choco_features[0].kind_of?(Hash)
+    end
+  end
+
   context "when installing" do
     context "with compiled choco client" do
       before :each do
-        @provider.stubs(:is_usepackageexitcodes_feature_enabled?).returns(false)
         @provider.class.stubs(:is_compiled_choco?).returns(true)
-        PuppetX::Chocolatey::ChocolateyInstall.expects(:install_path).returns('c:\dude')
+        PuppetX::Chocolatey::ChocolateyCommon.expects(:set_env_chocolateyinstall)
+        PuppetX::Chocolatey::ChocolateyCommon.stubs(:file_exists?).with('c:\dude\config\chocolatey.config').returns(true)
         PuppetX::Chocolatey::ChocolateyCommon.stubs(:file_exists?).with('c:\dude\bin\choco.exe').returns(true)
+        'c:\dude\config\chocolatey.config'
         PuppetX::Chocolatey::ChocolateyVersion.stubs(:version).returns(first_compiled_choco_version)
         # unhold is called in installs on compiled choco
         Puppet::Util::Execution.stubs(:execute)
@@ -80,7 +223,11 @@ describe provider do
         @provider.install
       end
 
-      it "should call with ignore package exit codes when = 0.9.10" do
+      it "should call with ignore package exit codes when = 0.9.10 and not explicitly configured to use them" do
+        PuppetX::Chocolatey::ChocolateyCommon.expects(:set_env_chocolateyinstall)
+        PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_config_file).returns(choco_config)
+        PuppetX::Chocolatey::ChocolateyCommon.expects(:file_exists?).with(choco_config).returns(true)
+        File.expects(:read).with(choco_config).returns choco_config_contents
         PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(minimum_supported_choco_exit_codes).at_least_once
         resource[:ensure] = :present
         @provider.expects(:chocolatey).with('install', 'chocolatey','-y', nil, '--ignore-package-exit-codes')
@@ -88,10 +235,26 @@ describe provider do
         @provider.install
       end
 
-      it "should call with ignore package exit codes when > 0.9.10" do
+      it "should call with ignore package exit codes when > 0.9.10 and not explicitly configured to use them" do
+        PuppetX::Chocolatey::ChocolateyCommon.expects(:set_env_chocolateyinstall)
+        PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_config_file).returns(choco_config)
+        PuppetX::Chocolatey::ChocolateyCommon.expects(:file_exists?).with(choco_config).returns(true)
+        File.expects(:read).with(choco_config).returns choco_config_contents
         PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(choco_zero_ten_zero).at_least_once
         resource[:ensure] = :present
         @provider.expects(:chocolatey).with('install', 'chocolatey','-y', nil, '--ignore-package-exit-codes')
+
+        @provider.install
+      end
+
+      it "should not ignore package exit codes when = 0.9.10 and explicitly configured to use them" do
+        PuppetX::Chocolatey::ChocolateyCommon.expects(:set_env_chocolateyinstall)
+        PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_config_file).returns(choco_config)
+        PuppetX::Chocolatey::ChocolateyCommon.expects(:file_exists?).with(choco_config).returns(true)
+        File.expects(:read).with(choco_config).returns choco_config_contents_upec
+        PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(choco_zero_ten_zero).at_least_once
+        resource[:ensure] = :present
+        @provider.expects(:chocolatey).with('install', 'chocolatey','-y', nil)
 
         @provider.install
       end
@@ -186,7 +349,7 @@ describe provider do
   context "when uninstalling" do
     context "with compiled choco client" do
       before :each do
-        @provider.stubs(:is_usepackageexitcodes_feature_enabled?).returns(false)
+        @provider.stubs(:is_use_package_exit_codes_feature_enabled?).returns(false)
         @provider.class.stubs(:is_compiled_choco?).returns(true)
         PuppetX::Chocolatey::ChocolateyVersion.stubs(:version).returns(first_compiled_choco_version)
         # unhold is called in installs on compiled choco
@@ -261,7 +424,7 @@ describe provider do
   context "when updating" do
     context "with compiled choco client" do
       before :each do
-        @provider.stubs(:is_usepackageexitcodes_feature_enabled?).returns(false)
+        @provider.stubs(:is_use_package_exit_codes_feature_enabled?).returns(false)
         @provider.class.stubs(:is_compiled_choco?).returns(true)
         PuppetX::Chocolatey::ChocolateyVersion.stubs(:version).returns(first_compiled_choco_version)
         # unhold is called in installs on compiled choco
@@ -304,7 +467,6 @@ describe provider do
 
         @provider.update
       end
-
 
       it "should use `chocolatey install` when ensure latest and package absent" do
         provider.stubs(:instances).returns []

--- a/spec/unit/puppet/provider/package/chocolatey_spec.rb
+++ b/spec/unit/puppet/provider/package/chocolatey_spec.rb
@@ -64,6 +64,7 @@ describe provider do
   context "when installing" do
     context "with compiled choco client" do
       before :each do
+        @provider.stubs(:is_usepackageexitcodes_feature_enabled?).returns(false)
         @provider.class.stubs(:is_compiled_choco?).returns(true)
         PuppetX::Chocolatey::ChocolateyInstall.expects(:install_path).returns('c:\dude')
         PuppetX::Chocolatey::ChocolateyCommon.stubs(:file_exists?).with('c:\dude\bin\choco.exe').returns(true)
@@ -185,6 +186,7 @@ describe provider do
   context "when uninstalling" do
     context "with compiled choco client" do
       before :each do
+        @provider.stubs(:is_usepackageexitcodes_feature_enabled?).returns(false)
         @provider.class.stubs(:is_compiled_choco?).returns(true)
         PuppetX::Chocolatey::ChocolateyVersion.stubs(:version).returns(first_compiled_choco_version)
         # unhold is called in installs on compiled choco
@@ -259,6 +261,7 @@ describe provider do
   context "when updating" do
     context "with compiled choco client" do
       before :each do
+        @provider.stubs(:is_usepackageexitcodes_feature_enabled?).returns(false)
         @provider.class.stubs(:is_compiled_choco?).returns(true)
         PuppetX::Chocolatey::ChocolateyVersion.stubs(:version).returns(first_compiled_choco_version)
         # unhold is called in installs on compiled choco


### PR DESCRIPTION
When the "usepackageexitcodes" feature is enabled with the
chocolateyfeature resource, this commit ensures that the
--ignore-package-exit-codes argument is not passed to the choco binary
and that the feature is respected.

Previously, the --ignore-package-exit-codes argument would be passed all
the time (on versions of Chocolatey where it existed) and this would
result in the enabling of the "usepackageexitcodes" feature to be
rendered moot.