### PR TITLE
(MODULES-5654) Support for proxies during installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,12 @@ class {'chocolatey':
 }
 ~~~
 
+#### Install chocolatey using a proxy server
+
+~~~puppet
+class {'chocolatey':
+  install_proxy => 'http://proxy.megacorp.com:3128',
+}
 
 ### Configuration
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -59,6 +59,8 @@
 #   `false`.
 # @param [String] chocolatey_version chocolatey version, falls back to
 #   `$::chocolateyversion`.
+# @param install_proxy Proxy server to use to use for installation of chocolatey itself or
+#   `undef` to not use a proxy
 class chocolatey (
   $choco_install_location         = $::chocolatey::params::install_location,
   $use_7zip                       = $::chocolatey::params::use_7zip,
@@ -66,7 +68,8 @@ class chocolatey (
   $chocolatey_download_url        = $::chocolatey::params::download_url,
   $enable_autouninstaller         = $::chocolatey::params::enable_autouninstaller,
   $log_output                     = false,
-  $chocolatey_version             = $::chocolatey::params::chocolatey_version
+  $chocolatey_version             = $::chocolatey::params::chocolatey_version,
+  $install_proxy                  = undef,
 ) inherits ::chocolatey::params {
 
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -2,8 +2,14 @@
 class chocolatey::install {
   assert_private()
 
-  $download_url = $::chocolatey::chocolatey_download_url
-  $unzip_type   = $::chocolatey::use_7zip ? {
+  $install_proxy = $::chocolatey::install_proxy
+  $_install_proxy = $install_proxy ? {
+    undef   => '$false',
+    default => "'${install_proxy}'",
+  }
+
+  $download_url  = $::chocolatey::chocolatey_download_url
+  $unzip_type    = $::chocolatey::use_7zip ? {
     true      => '7zip',
     default   => 'windows'
   }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -26,6 +26,16 @@ describe 'chocolatey' do
     end
   end
 
+  context "accepts install_proxy parameter" do
+    let(:params) {{
+      :install_proxy => 'http://proxy.megacorp.com:3128',
+    }}
+
+    it 'should compile successfully' do
+      catalogue
+    end
+  end
+
   context "chocolatey_download_url =>" do
     ['https://chocolatey.org/api/v2/package/chocolatey/','http://location','file:///c:/somwhere/chocolatey.nupkg'].each do |param_value|
       context "#{param_value}" do

--- a/templates/InstallChocolatey.ps1.erb
+++ b/templates/InstallChocolatey.ps1.erb
@@ -23,6 +23,7 @@ $ErrorActionPreference = 'Stop'
 # variables
 $url = '<%= @download_url %>'
 $unzipMethod = '<%= @unzip_type %>'
+$install_proxy = <%= @_install_proxy %>
 if ($env:TEMP -eq $null) {
   $env:TEMP = Join-Path $env:SystemDrive 'temp'
 }
@@ -82,6 +83,11 @@ param (
  )
   Write-Output "Downloading $url to $file"
   $downloader = new-object System.Net.WebClient
+
+  if ($install_proxy) {
+    [System.Net.WebRequest]::DefaultWebProxy = New-Object System.Net.WebProxy($install_proxy,$true)
+  }
+
   $downloader.Proxy.Credentials=[System.Net.CredentialCache]::DefaultNetworkCredentials;
   $downloader.DownloadFile($url, $file)
 }


### PR DESCRIPTION
Add a new parameter `install_proxy` to specify a proxy server to use during installation in the form `http://proxy.megacorp.com:3128`.  This will be conditionally munged into the `InstallChocolatey.ps1.erb` script and used to configure the `System.Net.WebRequest` instance which is used to download all required assets