### PR TITLE
(MODULES-5859) Fix An already initialized constant' warning when doing a "puppet apply"

### DIFF
--- a/lib/puppet_x/chocolatey/chocolatey_version.rb
+++ b/lib/puppet_x/chocolatey/chocolatey_version.rb
@@ -5,7 +5,7 @@ module PuppetX
   module Chocolatey
     class ChocolateyVersion
 
-      OLD_CHOCO_MESSAGE = "Please run chocolatey /? or chocolatey help - chocolatey v"
+      OLD_CHOCO_MESSAGE = "Please run chocolatey /? or chocolatey help - chocolatey v" unless defined? OLD_CHOCO_MESSAGE
 
       def self.version
         version = nil


### PR DESCRIPTION
This fixes an issue where warning is thrown that a OLD_CHOCO_MESSAGE constant is already initialized when a "puppet apply" is used (does not occur within a "puppet agent" run). The warning this fixes is as per the output below:

```
[root@master ~]# puppet apply -e 'notice("test")'
/opt/puppetlabs/puppet/cache/lib/puppet_x/chocolatey/chocolatey_version.rb:8: warning: already initialized constant PuppetX::Chocolatey::ChocolateyVersion::OLD_CHOCO_MESSAGE
/etc/puppetlabs/code/environments/production/modules/chocolatey/lib/puppet_x/chocolatey/chocolatey_version.rb:8: warning: previous definition of OLD_CHOCO_MESSAGE was here
Notice: Scope(Class[main]): test
Notice: Compiled catalog for master.paulreed.ca in environment production in 0.15 seconds
Notice: Applied catalog in 0.92 seconds
```
