### PR TITLE
(MODULES-6652) Fix download 7z behind proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+### Added
+
+- Parameter `seven_zip_download_url` to make the source of the 7zip binary configurable, allowing the use of this module when the previously hardcoded URL cannot be reached ([MODULES-6652](https://tickets.puppetlabs.com/browse/MODULES-6652)). Thanks, [Daniel Helgenberger](https://github.com/helge000)!
+
 ## [3.2.0] - 2019-02-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -793,6 +793,10 @@ If you override the default installation directory you need to set appropriate p
 
 Specifies whether to use the built-in shell or allow the installer to download 7zip to extract `chocolatey.nupkg` during installation. Valid options: `true`, `false`. Default: `false`.
 
+##### `seven_zip_download_url`
+
+Specifies the source file for `7za.exe`. Supports all sources supported by Puppet's `file {}` resource. You should use a 32bit binary for compatibility.  Defaults to `https://chocolatey.org/7za.exe`
+
 ##### `choco_install_timeout_seconds`
 
 Specifies how long in seconds should be allowed for the install of Chocolatey (including .NET Framework 4 if necessary). Valid options: Number. Default: `1500` (25 minutes).

--- a/lib/facter/choco_temp_dir.rb
+++ b/lib/facter/choco_temp_dir.rb
@@ -1,0 +1,9 @@
+require 'pathname'
+require Pathname.new(__FILE__).dirname + '../' + 'puppet_x/chocolatey/chocolatey_install'
+
+Facter.add('choco_temp_dir') do
+  confine :osfamily => :windows
+  setcode do
+    PuppetX::Chocolatey::ChocolateyInstall.temp_dir || ENV['TEMP']
+  end
+end

--- a/lib/puppet_x/chocolatey/chocolatey_install.rb
+++ b/lib/puppet_x/chocolatey/chocolatey_install.rb
@@ -29,6 +29,36 @@ module PuppetX
 
         value
       end
+
+      def self.temp_dir
+        if Puppet::Util::Platform.windows?
+          require 'win32/registry'
+  
+          value = nil
+          begin
+            # looking at current user may likely fail because it's likely going to be LocalSystem
+            hive = Win32::Registry::HKEY_CURRENT_USER
+            hive.open('Environment', Win32::Registry::KEY_READ | 0x100) do |reg|
+              value = reg['TEMP']
+            end
+          rescue Win32::Registry::Error => e
+            value = nil
+          end
+  
+          if value.nil?
+            begin
+              hive = Win32::Registry::HKEY_LOCAL_MACHINE
+              hive.open('SYSTEM\CurrentControlSet\Control\Session Manager\Environment', Win32::Registry::KEY_READ | 0x100) do |reg|
+                value = reg['TEMP']
+              end
+            rescue Win32::Registry::Error => e
+              value = nil
+            end
+          end
+
+          value
+        end
+      end
     end
   end
 end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,6 +43,10 @@
 # @param [Boolean] use_7zip Whether to use built-in shell or allow installer
 #   to download 7zip to extract `chocolatey.nupkg` during installation.
 #   Defaults to `false`.
+# @param [String] seven_zip_download_url Specifies the source file for 7za.exe.
+#   Supports all sources supported by Puppet's file resource. You should use
+#   a 32bit binary for compatibility.
+#   Defaults to 'https://chocolatey.org/7za.exe'.
 # @param [Integer] choco_install_timeout_seconds How long in seconds should
 #   be allowed for the install of Chocolatey (including .NET Framework 4 if
 #   necessary). Defaults to `1500` (25 minutes).
@@ -65,6 +69,7 @@
 class chocolatey (
   $choco_install_location         = $::chocolatey::params::install_location,
   $use_7zip                       = $::chocolatey::params::use_7zip,
+  $seven_zip_download_url         = $::chocolatey::params::seven_zip_download_url,
   $choco_install_timeout_seconds  = $::chocolatey::params::install_timeout_seconds,
   $chocolatey_download_url        = $::chocolatey::params::download_url,
   $enable_autouninstaller         = $::chocolatey::params::enable_autouninstaller,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,11 +7,21 @@ class chocolatey::install {
     undef   => '$false',
     default => "'${install_proxy}'",
   }
+  $download_url            = $::chocolatey::chocolatey_download_url
+  $seven_zip_download_url  = $::chocolatey::seven_zip_download_url
+  $seven_zip_exe           = "${facts['choco_temp_dir']}\\7za.exe"
 
-  $download_url  = $::chocolatey::chocolatey_download_url
-  $unzip_type    = $::chocolatey::use_7zip ? {
-    true      => '7zip',
-    default   => 'windows'
+  if $::chocolatey::use_7zip {
+    $unzip_type = '7zip'
+    file { $seven_zip_exe:
+      ensure  => present,
+      source  => $seven_zip_download_url,
+      replace => false,
+      mode    => '0755',
+      before  => Exec['install_chocolatey_official'],
+    }
+  } else {
+    $unzip_type = 'windows'
   }
 
   registry_value { 'ChocolateyInstall environment value':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,6 +3,7 @@ class chocolatey::params {
   $install_location         = $::choco_install_path # default is C:\ProgramData\chocolatey
   $download_url             = 'https://chocolatey.org/api/v2/package/chocolatey/'
   $use_7zip                 = false
+  $seven_zip_download_url   = 'https://chocolatey.org/7za.exe'
   $install_timeout_seconds  = 1500
   $enable_autouninstaller   = true
   $chocolatey_version       = $::chocolateyversion

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'chocolatey' do
     {
       :chocolateyversion  => '0.9.9.8',
       :choco_install_path => 'C:\ProgramData\chocolatey',
+      :choco_temp_dir     => 'C:\Temp',
       :path => 'C:\something',
     }
   }
@@ -25,6 +26,27 @@ RSpec.describe 'chocolatey' do
         let(:params) {{ :choco_install_timeout_seconds => param_value }}
 
         it { is_expected.to contain_exec('install_chocolatey_official').with_timeout("#{param_value}") }
+      end
+    end
+
+    context "use_7zip => false" do
+      let(:params) {{ :use_7zip => false }}
+      it { 
+        is_expected.not_to contain_file('C:\Temp\7za.exe')
+      }
+    end
+
+    context "use_7zip => true" do
+      context "seven_zip_download_url default" do
+        let(:params) {{ :use_7zip => true }}
+        it { is_expected.to contain_file('C:\Temp\7za.exe').with_source('https://chocolatey.org/7za.exe')}
+      end
+      context "seven_zip_download_url => 'https://packages.organization.net/7za.exe'" do
+        let(:params) {{
+          :use_7zip      => true,
+          :seven_zip_download_url => 'https://packages.organization.net/7za.exe'
+        }}
+        it { is_expected.to contain_file('C:\Temp\7za.exe').with_source('https://packages.organization.net/7za.exe')}
       end
     end
   end

--- a/spec/unit/facter/choco_temp_dir.rb
+++ b/spec/unit/facter/choco_temp_dir.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+require 'facter'
+require 'puppet_x/chocolatey/chocolatey_install'
+
+describe 'choco_temp_dir fact' do
+  subject(:fact) { Facter.fact(:choco_temp_dir) }
+
+  before :each do
+    Facter.clear
+    Facter.clear_messages
+  end
+
+  it "should return the TEMP directory" do
+    skip ('Not on Windows platform') unless Puppet::Util::Platform.windows?
+    expected_value = 'waffles'
+    PuppetX::Chocolatey::ChocolateyInstall.expects(:temp_dir).returns(expected_value)
+
+    subject.value.must == expected_value
+  end
+  it "should return the default path when PuppetX::Chocolatey::ChocolateyInstall.install_path is nil" do
+    skip ('Not on Windows platform') unless Puppet::Util::Platform.windows?
+    PuppetX::Chocolatey::ChocolateyInstall.expects(:temp_dir).returns(nil)
+
+    subject.value.must == ENV['TEMP']
+  end
+
+
+  after :each do
+    Facter.clear
+    Facter.clear_messages
+  end
+end

--- a/spec/unit/puppet_x/chocolatey/chocolatey_install_spec.rb
+++ b/spec/unit/puppet_x/chocolatey/chocolatey_install_spec.rb
@@ -50,3 +50,19 @@ describe 'Chocolatey Install Location' do
   end
 
 end
+
+describe 'Chocolatey Temp Directory' do
+  it "should return the TEMP path from registry if it exists" do
+    skip ('Not on Windows platform') unless Puppet::Util::Platform.windows?
+    expected_value = 'C:\somewhere'
+    Win32::Registry.any_instance.expects(:[]).with('TEMP').returns(expected_value)
+
+    PuppetX::Chocolatey::ChocolateyInstall.temp_dir.must == expected_value
+  end
+  it "should return nil path from registry if it does not exist" do
+    skip ('Not on Windows platform') unless Puppet::Util::Platform.windows?
+    Win32::Registry.any_instance.expects(:[]).with('TEMP').raises(Win32::Registry::Error.new(2), 'file not found yo').twice
+
+    PuppetX::Chocolatey::ChocolateyInstall.temp_dir.must be_nil
+  end
+end

--- a/templates/InstallChocolatey.ps1.erb
+++ b/templates/InstallChocolatey.ps1.erb
@@ -24,6 +24,7 @@ $ErrorActionPreference = 'Stop'
 $url = '<%= @download_url %>'
 $unzipMethod = '<%= @unzip_type %>'
 $install_proxy = <%= @_install_proxy %>
+$7zaExe = '<%= @seven_zip_exe %>'
 if ($env:TEMP -eq $null) {
   $env:TEMP = Join-Path $env:SystemDrive 'temp'
 }
@@ -96,15 +97,10 @@ param (
 Download-File $url $file
 
 if ($unzipMethod -eq '7zip') {
-  # download 7zip
-  Write-Output "Download 7Zip commandline tool"
-  $7zaExe = Join-Path $tempDir '7za.exe'
-
-  Download-File 'https://chocolatey.org/7za.exe' "$7zaExe"
-
   # unzip the package
   Write-Output "Extracting $file to $tempDir..."
   Start-Process "$7zaExe" -ArgumentList "x -o`"$tempDir`" -y `"$file`"" -Wait -NoNewWindow
+  Remove-Item -Path "$7zaExe" -Force
 } else {
   if ($PSVersionTable.PSVersion.Major -lt 5) {
     $shellApplication = new-object -com shell.application
@@ -126,7 +122,7 @@ if ($PSVersionTable.PSVersion.Major -gt 2) {
 } else {
   $output = Invoke-Expression $chocInstallPS1
   $output
-  Write-Output "Any errors that occured during install or upgrade are logged here: $chocoErrorLog"
+  Write-Output "Any errors that occurred during install or upgrade are logged here: $chocoErrorLog"
   $error | out-file $chocErrorLog
 }
 


### PR DESCRIPTION
Adds a local file '7za.exe' witch is copied to $::system32 in case unzip
method is '7zip'.
7za - source: https://chocolatey.org/7za.exe, witch was originally used
in the template.