### PR TITLE
(MODULES-6734) Add Beakser Testmode Switcher

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,7 @@ group :system_tests do
   gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')        
   gem "puppet-blacksmith", '~> 3.4',                                             :require => false
   gem "beaker-windows", '~> 0.6',                                                :require => false
+  gem "beaker-testmode_switcher"
 end
 
 gem 'puppet', *location_for(ENV['PUPPET_GEM_VERSION'])

--- a/spec/acceptance/features_spec.rb
+++ b/spec/acceptance/features_spec.rb
@@ -25,7 +25,7 @@ describe 'Chocolatey features' do
       end
 
       it 'Should apply the manifest to disable the feature' do
-        apply_manifest_on(agent, chocolatey_src, :catch_failures => true)
+        execute_manifest_on(agent, chocolatey_src, :catch_failures => true)
       end
 
       it 'should verify the feature is still disabled' do
@@ -60,7 +60,7 @@ describe 'Chocolatey features' do
       end
 
       it 'should apply the manifest to disable the feature' do
-        apply_manifest_on(agent, chocolatey_src)
+        execute_manifest_on(agent, chocolatey_src)
       end
 
       it 'should validate the feature is now disabled' do
@@ -95,7 +95,7 @@ describe 'Chocolatey features' do
       end
 
       it 'should apply the manifest to enable the feature' do
-        apply_manifest_on(agent, chocolatey_src, :catch_failures => true)
+        execute_manifest_on(agent, chocolatey_src, :catch_failures => true)
       end
 
       it 'Should verify the feature is now enabled' do
@@ -130,7 +130,7 @@ describe 'Chocolatey features' do
       end
 
       it 'should apply the manifest to enable the feature' do
-        apply_manifest_on(agent, chocolatey_src, :catch_failures => true)
+        execute_manifest_on(agent, chocolatey_src, :catch_failures => true)
       end
 
       it 'Should verify the feature is still enabled' do
@@ -159,7 +159,7 @@ describe 'Chocolatey features' do
 
     windows_agents.each do | agent |
       it 'Should fail to apply the manifest' do
-        apply_manifest_on(agent, chocolatey_src, :expect_failures => true) do | result |
+        execute_manifest_on(agent, chocolatey_src, :expect_failures => true) do | result |
           assert_match(/returned 1: Feature 'idontexistfeature123123' not found/, result.stderr, "stderr did not match expected")
         end
       end
@@ -184,7 +184,7 @@ describe 'Chocolatey features' do
 
     windows_agents.each do | agent |
       it 'Should fail to apply the manifest' do
-        apply_manifest_on(agent, chocolatey_src, :expect_failures => true) do | result |
+        execute_manifest_on(agent, chocolatey_src, :expect_failures => true) do | result |
           assert_match(/returned 1: Feature 'idontexistfeature123123' not found/, result.stderr, "stderr did not match expected")
         end
       end
@@ -209,7 +209,7 @@ describe 'Chocolatey features' do
 
     windows_agents.each do | agent |
       it 'Should fail to apply the manifest' do
-        apply_manifest_on(agent, chocolatey_src, :expect_failures => true) do | result |
+        execute_manifest_on(agent, chocolatey_src, :expect_failures => true) do | result |
           assert_match(/Error: Parameter ensure failed on Chocolateyfeature\[checksumFiles\]: Invalid value \"absent\"/, result.stderr, "stderr did not match expected")
         end
       end

--- a/spec/acceptance/package_spec.rb
+++ b/spec/acceptance/package_spec.rb
@@ -40,7 +40,7 @@ describe 'Chocolatey Package' do
 
       it 'Should apply the manifest to install the package' do
 
-        apply_manifest_on(agent, chocolatey_package_manifest, :catch_failures => true) do | result |
+        execute_manifest_on(agent, chocolatey_package_manifest, :catch_failures => true) do | result |
           assert_match(/Notice\: \/Stage\[main\]\/Main\/Package\[#{package_name}\]\/ensure\: created/, result.stdout, "stdout did not report package creation of #{package_name}")
         end
       end
@@ -52,7 +52,7 @@ describe 'Chocolatey Package' do
       end
 
       it 'Should uninstall the package' do
-        apply_manifest_on(agent, chocolatey_package_manifest_chng, :catch_failures => true) do | result |
+        execute_manifest_on(agent, chocolatey_package_manifest_chng, :catch_failures => true) do | result |
           assert_match(/Stage\[main\]\/Main\/Package\[#{package_name}\]\/ensure\: removed/, result.stdout, "stdout did not report package removal of #{package_name}")
         end
       end
@@ -96,7 +96,7 @@ describe 'Chocolatey Package' do
       end
 
       it 'Should apply the manifest to install the package' do
-        apply_manifest_on(agent, chocolatey_package_manifest, :catch_failures => true) do | result |
+        execute_manifest_on(agent, chocolatey_package_manifest, :catch_failures => true) do | result |
           assert_match(/Notice\: \/Stage\[main\]\/Main\/Package\[#{package_name}\]\/ensure\: created/, result.stdout, "stdout did not report package creation of #{package_name}")
         end
       end
@@ -108,7 +108,7 @@ describe 'Chocolatey Package' do
       end
 
       it 'Should uninstall the package' do
-        apply_manifest_on(agent, chocolatey_package_manifest_chng, :catch_failures => true) do | result |
+        execute_manifest_on(agent, chocolatey_package_manifest_chng, :catch_failures => true) do | result |
           assert_match(/Stage\[main\]\/Main\/Package\[#{package_name}\]\/ensure\: removed/, result.stdout, "stdout did not report package removal of #{package_name}")
         end
       end

--- a/spec/acceptance/sources_spec.rb
+++ b/spec/acceptance/sources_spec.rb
@@ -22,7 +22,7 @@ describe 'Chocolatey Source' do
           }
         PP
 
-        apply_manifest_on(agent, chocolatey_src, :catch_failures => true)
+        execute_manifest_on(agent, chocolatey_src, :catch_failures => true)
       end
 
       it 'Should now have proper priority' do
@@ -56,7 +56,7 @@ describe 'Chocolatey Source' do
           }
         PP
 
-        apply_manifest_on(agent, chocolatey_src, :catch_failures => true)
+        execute_manifest_on(agent, chocolatey_src, :catch_failures => true)
       end
 
       it 'Should have the correct properties' do
@@ -89,7 +89,7 @@ describe 'Chocolatey Source' do
           }
         PP
 
-        apply_manifest_on(agent, chocolatey_src, :catch_failures => true)
+        execute_manifest_on(agent, chocolatey_src, :catch_failures => true)
       end
 
       it 'Should verify the results' do
@@ -120,7 +120,7 @@ describe 'Chocolatey Source' do
           }
         PP
 
-        apply_manifest_on(agent, chocolatey_src, :catch_failures => true)
+        execute_manifest_on(agent, chocolatey_src, :catch_failures => true)
       end
 
       it 'Should verify results' do
@@ -153,7 +153,7 @@ describe 'Chocolatey Source' do
           }
         PP
 
-        apply_manifest_on(agent, chocolatey_src, :catch_failures => true)
+        execute_manifest_on(agent, chocolatey_src, :catch_failures => true)
       end
 
       it 'Should verify the results' do
@@ -186,7 +186,7 @@ describe 'Chocolatey Source' do
           }
         PP
 
-        apply_manifest_on(agent, chocolatey_src, :catch_failures => true)
+        execute_manifest_on(agent, chocolatey_src, :catch_failures => true)
       end
 
       it 'Should verify the setup was added' do
@@ -204,7 +204,7 @@ describe 'Chocolatey Source' do
           }
         PP
 
-        apply_manifest_on(agent, chocolatey_src_change, :catch_failures => true)
+        execute_manifest_on(agent, chocolatey_src_change, :catch_failures => true)
       end
 
       it 'Should verify results' do
@@ -234,7 +234,7 @@ describe 'Chocolatey Source' do
           }
         PP
 
-        apply_manifest_on(agent, chocolatey_src, :catch_failures => true)
+        execute_manifest_on(agent, chocolatey_src, :catch_failures => true)
       end
 
       it 'Should verify the results' do
@@ -266,7 +266,7 @@ describe 'Chocolatey Source' do
           }
         PP
 
-        apply_manifest_on(agent, chocolatey_src, :catch_failures => true)
+        execute_manifest_on(agent, chocolatey_src, :catch_failures => true)
       end
 
       it 'Should verify the results' do
@@ -287,7 +287,7 @@ describe 'Chocolatey Source' do
           }
         PP
 
-        apply_manifest_on(agent, chocolatey_src_change, :catch_failures => true)
+        execute_manifest_on(agent, chocolatey_src_change, :catch_failures => true)
       end
 
       it 'Should validate the results' do
@@ -317,8 +317,8 @@ describe 'Chocolatey Source' do
           }
         PP
 
-        apply_manifest_on(agent, chocolatey_src, :catch_failures => true)
-        apply_manifest_on(agent, chocolatey_src, :catch_changes => true)
+        execute_manifest_on(agent, chocolatey_src, :catch_failures => true)
+        execute_manifest_on(agent, chocolatey_src, :catch_changes => true)
       end
 
       it 'Should verify the results' do
@@ -347,7 +347,7 @@ describe 'Chocolatey Source' do
           }
         PP
 
-        apply_manifest_on(agent, chocolatey_src, :catch_failures => true)
+        execute_manifest_on(agent, chocolatey_src, :catch_failures => true)
       end
 
       it 'Should verify the results' do
@@ -376,7 +376,7 @@ describe 'Chocolatey Source' do
           }
         PP
 
-        apply_manifest_on(agent, chocolatey_src, :expect_failures => true) do | result |
+        execute_manifest_on(agent, chocolatey_src, :expect_failures => true) do | result |
           assert_match(/Error: Validation of Chocolateysource\[chocolatey\] failed: A non-empty location/, result.stderr, "stderr did not match expected")
         end
       end
@@ -402,7 +402,7 @@ describe 'Chocolatey Source' do
           }
         PP
 
-        apply_manifest_on(agent, chocolatey_src, :expect_failures => true) do | result |
+        execute_manifest_on(agent, chocolatey_src, :expect_failures => true) do | result |
           assert_match(/Error: Parameter ensure failed on Chocolateysource\[test\]: Invalid value "sad"/, result.stderr, "stderr did not match expected")
         end
       end
@@ -429,7 +429,7 @@ describe 'Chocolatey Source' do
           }
         PP
 
-        apply_manifest_on(agent, chocolatey_src, :expect_failures => true) do | result |
+        execute_manifest_on(agent, chocolatey_src, :expect_failures => true) do | result |
           assert_match(/Error: Validation of Chocolateysource\[chocolatey\] failed: If specifying user\/password, you must specify both values/, result.stderr, "stderr did not match expected")
         end
       end
@@ -456,7 +456,7 @@ describe 'Chocolatey Source' do
           }
         PP
 
-        apply_manifest_on(agent, chocolatey_src, :expect_failures => true) do | result |
+        execute_manifest_on(agent, chocolatey_src, :expect_failures => true) do | result |
           assert_match(/Error: Validation of Chocolateysource\[chocolatey\] failed: If specifying user\/password, you must specify both values/, result.stderr, "stderr did not match expected")
         end
       end
@@ -481,7 +481,7 @@ describe 'Chocolatey Source' do
           }
         PP
 
-        apply_manifest_on(agent, chocolatey_src, :catch_failures => true)
+        execute_manifest_on(agent, chocolatey_src, :catch_failures => true)
       end
 
       it 'Should verify the result' do
@@ -519,7 +519,7 @@ describe 'Chocolatey Source' do
       PP
 
       it 'Should apply a manifest' do
-        apply_manifest_on(agent, chocolatey_src, :catch_failures => true)
+        execute_manifest_on(agent, chocolatey_src, :catch_failures => true)
       end
 
       it 'Should verify setup' do
@@ -529,7 +529,7 @@ describe 'Chocolatey Source' do
       end
 
       it 'Should apply remove manifest' do
-        apply_manifest_on(agent, chocolatey_src_remove, :catch_failures => true)
+        execute_manifest_on(agent, chocolatey_src_remove, :catch_failures => true)
       end
 
       it 'Should verify results' do
@@ -568,7 +568,7 @@ describe 'Chocolatey Source' do
       PP
 
       it 'Should apply a manifest' do
-        apply_manifest_on(agent, chocolatey_src, :catch_failures => true)
+        execute_manifest_on(agent, chocolatey_src, :catch_failures => true)
       end
 
       it 'Should verify setup' do
@@ -580,7 +580,7 @@ describe 'Chocolatey Source' do
       end
 
       it 'Should apply remove manifest' do
-        apply_manifest_on(agent, chocolatey_src_remove, :catch_failures => true)
+        execute_manifest_on(agent, chocolatey_src_remove, :catch_failures => true)
       end
 
       it 'Should verify results' do

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,23 +1,20 @@
-# Not sure if these are still neeed.
-# require 'net/http'
-# require 'uri'
 require 'nokogiri'
-
 require 'beaker-rspec'
 require 'beaker/puppet_install_helper'
 require 'beaker/module_install_helper'
 require 'beaker/ca_cert_helper'
-#require 'beaker/testmode_switcher'
-#require 'beaker/testmode_switcher/dsl'
-#require 'beaker-puppet'
+require 'beaker/testmode_switcher/dsl'
+
 Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
 
 run_puppet_install_helper
 install_ca_certs
 
-windows_agents.each do |agent|
-  install_module_dependencies_on(agent)
-  install_module_on(agent)
-  install_chocolatey
+hosts.each do |host|
+  install_module_dependencies_on(host)
+  install_module_on(host)
 end
 
+windows_agents.each do |agent|
+  install_chocolatey
+end

--- a/spec/support/examples/failing_manifest.rb
+++ b/spec/support/examples/failing_manifest.rb
@@ -3,7 +3,7 @@ shared_examples 'a failing manifest' do |manifest, expected_error|
   windows_agents.each do |agent|
 
     it 'Should fail to apply a bad manifest' do
-      apply_manifest_on(agent, manifest, :expect_failures => true) do
+      execute_manifest_on(agent, manifest, :expect_failures => true) do
         assert_match(expected_error, stderr, "stderr did not match expected error")
       end
     end

--- a/spec/support/examples/manifest_removes_value.rb
+++ b/spec/support/examples/manifest_removes_value.rb
@@ -2,7 +2,7 @@ shared_examples 'a manifest that removes a config value' do |manifest, key|
   
   windows_agents.each do |agent|
     it 'should apply the manifest that removes the value' do
-      apply_manifest_on(agent, manifest, :catch_failures => true)
+      execute_manifest_on(agent, manifest, :catch_failures => true)
     end
 
     it 'should validate the key has been removed' do

--- a/spec/support/examples/password_value_should_be.rb
+++ b/spec/support/examples/password_value_should_be.rb
@@ -6,7 +6,7 @@ shared_examples 'a password that doesn\'t change' do |manifest, modify_manfiest,
     # Should apply the password here.
     # 'password' variable is set to the password hash value.
     it 'Should apply the manifest to set the password' do
-      apply_manifest_on(agent, manifest, :catch_failures => true)
+      execute_manifest_on(agent, manifest, :catch_failures => true)
       on(agent, config_content_command) do |result|
         password = get_xml_value("//config/add[@key='#{key}']/@value", result.output).to_s
         assert_match(/.+/, password, 'Value did not match')
@@ -15,7 +15,7 @@ shared_examples 'a password that doesn\'t change' do |manifest, modify_manfiest,
 
     it 'should validate the value' do
       # Apply a manifest with a modified password value
-      apply_manifest(modify_manfiest, :catch_failures => true)
+      execute_manifest_on(agent, modify_manfiest, :catch_failures => true)
       on(agent, config_content_command) do |result|
         # Verify here that the hash value in the config did not change.
         assert_match(password, get_xml_value("//config/add[@key='#{key}']/@value", result.output).to_s, 'Value should not have changed')

--- a/spec/support/examples/successful_config_change.rb
+++ b/spec/support/examples/successful_config_change.rb
@@ -3,7 +3,7 @@ shared_examples 'a successful config change' do |manifest, key, expected_value|
   windows_agents.each do |agent|
     
     it 'Should apply the config manifest' do
-        apply_manifest_on(agent, manifest, :catch_failures => true)
+        execute_manifest_on(agent, manifest, :catch_failures => true)
     end
 
     it 'should validate the value' do

--- a/spec/support/utilities/helpers.rb
+++ b/spec/support/utilities/helpers.rb
@@ -28,7 +28,7 @@ def install_chocolatey
 
     curl_on(agent, "#{get_latest_chocholatey_download_url} > C:/chocolatey.nupkg")
 
-    apply_manifest_on(agent, chocolatey_pp, opts) do |result|
+    execute_manifest_on(agent, chocolatey_pp, opts) do |result|
       assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')
     end
 


### PR DESCRIPTION
This change adds beaker/testmode_switcher to the module, ensuring that
tests are run properly whether the current host set up is agent only, or
has a master.