### PR TITLE
MODULES-7068 Only initialise constant when not defined

### DIFF
--- a/lib/puppet_x/chocolatey/chocolatey_common.rb
+++ b/lib/puppet_x/chocolatey/chocolatey_common.rb
@@ -7,9 +7,9 @@ module PuppetX
     module ChocolateyCommon
 
       ## determines if C# version of choco
-      FIRST_COMPILED_CHOCO_VERSION = '0.9.9.0'
-      MINIMUM_SUPPORTED_CHOCO_VERSION_EXIT_CODES = '0.9.10.0'
-      MINIMUM_SUPPORTED_CHOCO_UNINSTALL_SOURCE = '0.9.10.0'
+      FIRST_COMPILED_CHOCO_VERSION = '0.9.9.0' unless defined? FIRST_COMPILED_CHOCO_VERSION
+      MINIMUM_SUPPORTED_CHOCO_VERSION_EXIT_CODES = '0.9.10.0' unless defined? MINIMUM_SUPPORTED_CHOCO_VERSION_EXIT_CODES
+      MINIMUM_SUPPORTED_CHOCO_UNINSTALL_SOURCE = '0.9.10.0' unless defined? MINIMUM_SUPPORTED_CHOCO_UNINSTALL_SOURCE
 
       def file_exists?(path)
         File.exist?(path)


### PR DESCRIPTION
This commit adds unless defined statements around the constant initialization to avoid warnings