### PR TITLE
(PDK-1038) Remove rspec-puppet pin from Gemfile

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -37,10 +37,6 @@ Gemfile:
     ':development':
       - gem: rototiller
         version: '~> 1.0'
-      # rspec-puppet is pinned to < 2.6.0 due to https://github.com/rodjek/rspec-puppet/issues/577
-      - gem: 'rspec-puppet'
-        platforms: ["mswin", "mingw", "x64_mingw"]
-        version: '< 2.6.0'
 Rakefile:
   unmanaged: true
 spec/spec_helper.rb:

--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,6 @@ group :development do
   gem "fast_gettext", '1.1.0',                            :require => false if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new('2.1.0')
   gem "fast_gettext",                                     :require => false if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.1.0')
   gem "rototiller", '~> 1.0',                             :require => false
-  gem "rspec-puppet", '< 2.6.0',                          :require => false, :platforms => ["mswin", "mingw", "x64_mingw"]
 end
 
 group :system_tests do


### PR DESCRIPTION
rodjek/rspec-puppet#577 has been resolved and released, so this pin can
be removed and updates to rspec-puppet can be pulled in via the
puppet-module metagems again.