### PR TITLE
(MAINT) Update chocolatey sources to artifactory

### DIFF
--- a/spec/acceptance/package_spec.rb
+++ b/spec/acceptance/package_spec.rb
@@ -11,7 +11,7 @@ describe 'Chocolatey Package' do
       package { "#{package_name}":
         ensure   => present,
         provider => chocolatey,
-        source   => 'http://nexus.delivery.puppetlabs.net/service/local/nuget/choco-pipeline-tests/'
+        source   => 'https://artifactory.delivery.puppetlabs.net/artifactory/api/nuget/choco-pipeline-tests/'
       }
     PP
 
@@ -39,7 +39,6 @@ describe 'Chocolatey Package' do
       end
 
       it 'Should apply the manifest to install the package' do
-
         execute_manifest_on(agent, chocolatey_package_manifest, :catch_failures => true) do | result |
           assert_match(/Notice\: \/Stage\[main\]\/Main\/Package\[#{package_name}\]\/ensure\: created/, result.stdout, "stdout did not report package creation of #{package_name}")
         end
@@ -68,7 +67,7 @@ describe 'Chocolatey Package' do
       package { "#{package_name}":
         ensure  => present,
         provider => chocolatey,
-        source => 'http://nexus.delivery.puppetlabs.net/service/local/nuget/choco-pipeline-tests/'
+        source => 'https://artifactory.delivery.puppetlabs.net/artifactory/api/nuget/choco-pipeline-tests/'
       }
     PP
 

--- a/spec/support/utilities/helpers.rb
+++ b/spec/support/utilities/helpers.rb
@@ -1,4 +1,4 @@
-CHOCOLATEY_LATEST_INFO_URL = "http://nexus.delivery.puppetlabs.net/service/local/nuget/choco-pipeline-tests/Packages()?$filter=((Id%20eq%20%27chocolatey%27)%20and%20(not%20IsPrerelease))%20and%20IsLatestVersion"
+CHOCOLATEY_LATEST_INFO_URL = "https://artifactory.delivery.puppetlabs.net/artifactory/api/nuget/choco-pipeline-tests/Packages()?$filter=((Id%20eq%20%27chocolatey%27)%20and%20(not%20IsPrerelease))%20and%20IsLatestVersion"
 
 def get_latest_chocholatey_download_url
   uri = URI.parse(CHOCOLATEY_LATEST_INFO_URL)


### PR DESCRIPTION
Prior to this commit the URIs for chocolatey feeds in the acceptance test
suite pointed to the old nexus feeds which have gone dark. This caused the
acceptance tests to fail.  This commit updates those URLs to point to the
new and functional artifactory feeds instead, fixing the acceptance tests.