### PR TITLE
(MODULES-6948) Fix/generate types chocolateyfeature

### DIFF
--- a/lib/puppet/provider/chocolateyfeature/windows.rb
+++ b/lib/puppet/provider/chocolateyfeature/windows.rb
@@ -26,14 +26,14 @@ Puppet::Type.type(:chocolateyfeature).provide(:windows) do
   end
 
   def query
-    self.class.features.each do |feature|
+    self.class.choco_features.each do |feature|
       return feature.properties if @resource[:name][/\A\S*/].downcase == feature.name.downcase
     end
 
     return {}
   end
 
-  def self.get_features
+  def self.get_choco_features
     PuppetX::Chocolatey::ChocolateyCommon.set_env_chocolateyinstall
 
     choco_config = PuppetX::Chocolatey::ChocolateyCommon.choco_config_file
@@ -46,7 +46,7 @@ Puppet::Type.type(:chocolateyfeature).provide(:windows) do
     config.elements.to_a( '//feature' )
   end
 
-  def self.get_feature(element)
+  def self.get_choco_feature(element)
     feature = {}
     return feature if element.nil?
 
@@ -64,15 +64,15 @@ Puppet::Type.type(:chocolateyfeature).provide(:windows) do
     feature
   end
 
-  def self.features
-    get_features.collect do |item|
-      feature = get_feature(item)
+  def self.choco_features
+    get_choco_features.collect do |item|
+      feature = get_choco_feature(item)
       new(feature)
     end
   end
 
   def self.instances
-    features
+    choco_features
   end
 
   def self.prefetch(resources)
@@ -119,7 +119,7 @@ Puppet::Type.type(:chocolateyfeature).provide(:windows) do
     @property_hash.clear
     @property_flush.clear
 
-    self.class.features
+    self.class.choco_features
     @property_hash = query
   end
 

--- a/spec/unit/puppet/provider/chocolateyfeature/windows_spec.rb
+++ b/spec/unit/puppet/provider/chocolateyfeature/windows_spec.rb
@@ -92,9 +92,18 @@ describe provider do
     it "should have a query method" do
       @provider.should respond_to(:query)
     end
+
+    it "should have the standard feautures method" do
+      @provider.should respond_to(:features)
+    end
+
+    it "should return nil feature when element is nil" do
+      provider.features.must be == []
+    end
+
   end
 
-  context "self.get_features" do
+  context "self.get_choco_features" do
     before :each do
       PuppetX::Chocolatey::ChocolateyCommon.expects(:set_env_chocolateyinstall)
     end
@@ -103,7 +112,7 @@ describe provider do
       PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_config_file).returns(nil)
 
       expect {
-        provider.get_features
+        provider.get_choco_features
       }.to raise_error(Puppet::ResourceError, /Config file not found for Chocolatey/)
     end
 
@@ -112,7 +121,7 @@ describe provider do
       PuppetX::Chocolatey::ChocolateyCommon.expects(:file_exists?).with(choco_config).returns(false)
 
       expect {
-        provider.get_features
+        provider.get_choco_features
       }.to raise_error(Puppet::ResourceError, /was unable to locate config file at/)
     end
 
@@ -124,7 +133,7 @@ describe provider do
         PuppetX::Chocolatey::ChocolateyCommon.expects(:file_exists?).with(choco_config).returns(true)
         File.expects(:read).with(choco_config).returns choco_config_contents
 
-        features = provider.get_features
+        features = provider.get_choco_features
       end
 
       it "should match the count of features in the config" do
@@ -138,7 +147,7 @@ describe provider do
     end
   end
 
-  context "self.get_feature" do
+  context "self.get_choco_feature" do
     let (:element) {  REXML::Element.new('feature') }
     element_name = "default"
     element_enabled = 'true'
@@ -148,11 +157,11 @@ describe provider do
     end
 
     it "should return nil feature when element is nil" do
-      provider.get_feature(nil).must be == {}
+      provider.get_choco_feature(nil).must be == {}
     end
 
     it "should convert an element to a feature" do
-      feature = provider.get_feature(element)
+      feature = provider.get_choco_feature(element)
 
       feature[:name].must eq element_name
       feature[:ensure].must eq :enabled
@@ -162,7 +171,7 @@ describe provider do
       element.delete_attribute('enabled')
       element.add_attribute('enabled', 'false')
 
-      feature = provider.get_feature(element)
+      feature = provider.get_choco_feature(element)
       feature[:ensure].must eq :disabled
     end
   end


### PR DESCRIPTION
fix MODULES-6948 with changing the function name from features to choco_features. features is used by puppet internally to match providers and types (has_feature etc.). With renaming the feature function in the chocolateyfeature provider, it prevents this function to be executed when the types are getting generated on the master (and then fails because no chocolatey config can't be found).