### PR TITLE
pdksync - (MODULES-7658) use beaker3 in puppet-module-gems

### DIFF
--- a/.sync.yml
+++ b/.sync.yml
@@ -14,19 +14,6 @@ Gemfile:
           - mswin
           - mingw
           - x64_mingw
-      - gem: beaker
-        version: '~> 3.13'
-        from_env: BEAKER_VERSION
-      - gem: beaker-abs
-        version: '~> 0.1'
-        from_env: BEAKER_ABS_VERSION
-      - gem: beaker-pe
-      - gem: beaker-hostgenerator
-        version: '>= 0.0'
-        from_env: BEAKER_HOSTGENERATOR_VERSION
-      - gem: beaker-rspec
-        version: '>= 0.0'
-        from_env: BEAKER_RSPEC_VERSION
       - gem: beaker-testmode_switcher
         version: '~> 0.4'
       - gem: master_manipulator

--- a/Gemfile
+++ b/Gemfile
@@ -38,11 +38,6 @@ end
 group :system_tests do
   gem "puppet-module-posix-system-r#{minor_version}",                                        require: false, platforms: [:ruby]
   gem "puppet-module-win-system-r#{minor_version}",                                          require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 3.13')
-  gem "beaker-abs", *location_for(ENV['BEAKER_ABS_VERSION'] || '~> 0.1')
-  gem "beaker-pe",                                                                           require: false
-  gem "beaker-hostgenerator", *location_for(ENV['BEAKER_HOSTGENERATOR_VERSION'] || '>= 0.0')
-  gem "beaker-rspec", *location_for(ENV['BEAKER_RSPEC_VERSION'] || '>= 0.0')
   gem "beaker-testmode_switcher", '~> 0.4',                                                  require: false
   gem "master_manipulator",                                                                  require: false
   gem "puppet-blacksmith", '~> 3.4',                                                         require: false


### PR DESCRIPTION
(MODULES-7658) use beaker3 in puppet-module-gems
pdk version: `1.6.0` 
