### PR TITLE
pdksync - (MODULES-7658) use beaker4 in puppet-module-gems

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,3 +1,5 @@
+require 'beaker-pe'
+require 'beaker-puppet'
 require 'nokogiri'
 require 'beaker-rspec'
 require 'beaker/puppet_install_helper'
@@ -8,6 +10,7 @@ require 'beaker/testmode_switcher/dsl'
 Dir["./spec/support/**/*.rb"].sort.each { |f| require f }
 
 run_puppet_install_helper
+configure_type_defaults_on(hosts)
 install_ca_certs
 
 hosts.each do |host|


### PR DESCRIPTION
(MODULES-7658) use beaker4 in puppet-module-gems
pdk version: `1.6.0` 
