### PR TITLE
(WIN-231) Change curl_on command to add path to cacert bundle

### DIFF
--- a/spec/support/utilities/helpers.rb
+++ b/spec/support/utilities/helpers.rb
@@ -26,7 +26,7 @@ def install_chocolatey
       :acceptable_exit_codes => [0, 2]
     }
 
-    curl_on(agent, "#{get_latest_chocholatey_download_url} > C:/chocolatey.nupkg")
+    curl_on(agent, "--cacert 'C:/Program Files/Puppet Labs/Puppet/puppet/ssl/cert.pem' #{get_latest_chocholatey_download_url} > C:/chocolatey.nupkg")
 
     execute_manifest_on(agent, chocolatey_pp, opts) do |result|
       assert_no_match(/Error:/, result.stderr, 'Unexpected error was detected!')


### PR DESCRIPTION
Due to puppet packaging curl at C:/ProgramFiles64Folder/PuppetLabs/Puppet/puppet/ssl/cert.pem we have added a "cacert" parameter to chocolatey's "curl_on" command to point at the correct cert-bundle at C:\Program Files\Puppet Labs\Puppet\puppet\ssl\cert.pem.

This change may be reverted in the future if we remove puppets packaged curl or otherwise change its cert file path to the correct path.