### PR TITLE
(MODULES-6948) Fix to support environment cache type generation

### DIFF
--- a/lib/puppet/provider/chocolateyfeature/windows.rb
+++ b/lib/puppet/provider/chocolateyfeature/windows.rb
@@ -26,7 +26,7 @@ Puppet::Type.type(:chocolateyfeature).provide(:windows) do
   end
 
   def query
-    self.class.features.each do |feature|
+    self.class.all_features.each do |feature|
       return feature.properties if @resource[:name][/\A\S*/].downcase == feature.name.downcase
     end
 
@@ -64,7 +64,7 @@ Puppet::Type.type(:chocolateyfeature).provide(:windows) do
     feature
   end
 
-  def self.features
+  def self.all_features
     get_features.collect do |item|
       feature = get_feature(item)
       new(feature)
@@ -72,7 +72,7 @@ Puppet::Type.type(:chocolateyfeature).provide(:windows) do
   end
 
   def self.instances
-    features
+    all_features
   end
 
   def self.prefetch(resources)
@@ -119,7 +119,7 @@ Puppet::Type.type(:chocolateyfeature).provide(:windows) do
     @property_hash.clear
     @property_flush.clear
 
-    self.class.features
+    self.class.all_features
     @property_hash = query
   end
 


### PR DESCRIPTION
I'm guessing `features` method has special meaning with types and providers and was getting invoked when run like this:

```
[root@puppet-test test_puppet_foreman]#  puppet generate types --environment test_puppet_foreman --trace
Notice: Generating Puppet resource types.
Notice: Generating '/etc/puppetlabs/code/environments/test_puppet_foreman/.resource_types/chocolateyconfig.pp' using 'pcore' format.
Error: /etc/puppetlabs/code/environments/test_puppet_foreman/modules/chocolatey/lib/puppet/type/chocolateyfeature.rb: Config file not found for Chocolatey. Please make sure you have Chocolatey installed.
```
After this change:

```
[root@puppet-test test_puppet_foreman]# puppet generate types --environment test_puppet_foreman --trace
Notice: Generating Puppet resource types.
Notice: Generating '/etc/puppetlabs/code/environments/test_puppet_foreman/.resource_types/chocolateyconfig.pp' using 'pcore' format.
Notice: Generating '/etc/puppetlabs/code/environments/test_puppet_foreman/.resource_types/chocolateyfeature.pp' using 'pcore' format.
Notice: Generating '/etc/puppetlabs/code/environments/test_puppet_foreman/.resource_types/chocolateysource.pp' using 'pcore' format.
[root@puppet-test test_puppet_foreman]# 
```