### PR TITLE
(MODULES-4418) Add bypass_proxy to chocolateysource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 ## [Unreleased]
 
+### Added
+
+- Configuration option for `chocolateysource` to allow bypassing any system-configured proxies ([MODULES-4418](https://tickets.puppetlabs.com/browse/MODULES-4418)).
+
 ### Fixed
 
 - Ensure the `source` syntax in the provider is correct ([MODULES-8493](https://tickets.puppetlabs.com/browse/MODULES-8493)). Thanks, [@jcwest](https://github.com/jcwest)!

--- a/README.md
+++ b/README.md
@@ -677,6 +677,14 @@ Specifies an optional user password for authenticated feeds. Not ensurable. Valu
 
 Specifies an optional priority for explicit feed order when searching for packages across multiple feeds. The lower the number, the higher the priority. Sources with a 0 priority are considered no priority and are added after other sources with a priority number. Requires at least Chocolatey v0.9.9.9. Default: `0`.
 
+#### `bypass_proxy`
+
+(**Property**: This parameter represents a concrete state on the target system.)
+
+Specifies an option to specify whether this source should explicitly bypass any explicitly or system configured proxies.
+Requires at least Chocolatey v0.10.4.
+Defaults to `false`.
+
 ### ChocolateyFeature
 
 Allows managing features for Chocolatey. Features are configurations that

--- a/lib/puppet/type/chocolateysource.rb
+++ b/lib/puppet/type/chocolateysource.rb
@@ -107,6 +107,21 @@ Puppet::Type.newtype(:chocolateysource) do
     defaultto(0)
   end
 
+  newproperty(:bypass_proxy, :boolean => true) do
+    desc "Option to specify whether this source should
+      explicitly bypass any explicitly or system
+      configured proxies.
+      Requires at least Chocolatey v0.10.4.
+      Defaults to false."
+    
+    newvalues(:true, :false)
+    defaultto(:false)
+
+    munge do |value|
+      resource.munge_boolean(value)
+    end
+  end
+
   validate do
     if (!self[:user].nil? && self[:user].strip != '' && (self[:password].nil? || self[:password] == '')) || ((self[:user].nil? || self[:user].strip == '') && !self[:password].nil? && self[:password] != '')
       raise ArgumentError, "If specifying user/password, you must specify both values."

--- a/spec/acceptance/sources_spec.rb
+++ b/spec/acceptance/sources_spec.rb
@@ -33,6 +33,38 @@ describe 'Chocolatey Source' do
     end
   end
 
+  context 'MODULES-4418 - Add Bypass Proxy to an Existing Source' do
+
+    before(:all) do
+      backup_config
+    end
+
+    after(:all) do
+      reset_config
+    end
+
+    windows_agents.each do | agent |
+
+      it 'Should Apply the Manifest' do
+        chocolatey_src = <<-PP
+          chocolateysource {'chocolatey':
+            ensure   => present,
+            location => 'https://chocolatey.org/api/v2',
+            bypass_proxy => true,
+          }
+        PP
+
+        execute_manifest_on(agent, chocolatey_src, :catch_failures => true)
+      end
+
+      it 'Should now bypass system proxies' do
+        on(agent, config_content_command) do |result|
+          assert_match(/true/, get_xml_value("//sources/source[@id='chocolatey']/@bypassProxy", result.output).to_s, 'Bypass Proxy did not match')
+        end
+      end
+    end
+  end
+
   context 'MODULES-3037 - Add Source With All Options' do
 
     before(:all) do
@@ -48,11 +80,12 @@ describe 'Chocolatey Source' do
       it 'Should Apply the Manifest' do
         chocolatey_src = <<-PP
           chocolateysource {'test':
-            ensure   => present,
-            location => 'c:\\packages',
-            priority => 2,
-            user     => 'bob',
-            password => 'yes',
+            ensure       => present,
+            location     => 'c:\\packages',
+            priority     => 2,
+            user         => 'bob',
+            password     => 'yes',
+            bypass_proxy => true,
           }
         PP
 
@@ -66,6 +99,7 @@ describe 'Chocolatey Source' do
           assert_match(/bob/, get_xml_value("//sources/source[@id='test']/@user", result.output).to_s, 'User did not match')
           assert_match(/.+/, get_xml_value("//sources/source[@id='test']/@password", result.output).to_s, 'Password was not saved')
           assert_match(/false/, get_xml_value("//sources/source[@id='test']/@disabled", result.output).to_s, 'Disabled did not match')
+          assert_match(/true/, get_xml_value("//sources/source[@id='test']/@bypassProxy", result.output).to_s, 'Bypass Proxy did not match')
         end
       end
     end
@@ -210,6 +244,55 @@ describe 'Chocolatey Source' do
       it 'Should verify results' do
         on(agent, config_content_command) do | result |
           assert_match(/5/, get_xml_value("//sources/source[@id='chocolatey']/@priority", result.output).to_s, 'Priority change did not match')
+        end
+      end
+    end
+  end
+
+  context 'MODULES-4418 - Change Existing Bypass Proxy Setting' do
+
+    before(:all) do
+      backup_config
+    end
+    
+    after(:all) do
+      reset_config
+    end
+
+    windows_agents.each do | agent |
+      it 'Should apply a manifest to set bypass_proxy' do
+        chocolatey_src = <<-PP
+          chocolateysource {'chocolatey':
+            ensure   => present,
+            location => 'https://chocolatey.org/api/v2',
+            bypass_proxy => true,
+          }
+        PP
+
+        execute_manifest_on(agent, chocolatey_src, :catch_failures => true)
+      end
+
+      it 'Should verify the setup was added' do
+        on(agent, config_content_command) do | result |
+          assert_match(/true/, get_xml_value("//sources/source[@id='chocolatey']/@bypassProxy", result.output).to_s, 'Bypass Proxy setup did not match')
+        end
+      end
+
+      it 'Should apply a manifest to set bypass_proxy to false' do
+        chocolatey_src_change = <<-PP
+          chocolateysource {'chocolatey':
+            ensure   => present,
+            location => 'https://chocolatey.org/api/v2',
+            bypass_proxy => false,
+          }
+        PP
+
+        execute_manifest_on(agent, chocolatey_src_change, :catch_failures => true)
+      end
+
+      it 'Should verify results' do
+        on(agent, config_content_command) do | result |
+          assert_match(/false/, get_xml_value("//sources/source[@id='chocolatey']/@bypassProxy", result.output).to_s, 'Bypass Proxy change did not match')
         end
       end
     end
@@ -535,6 +618,54 @@ describe 'Chocolatey Source' do
       it 'Should verify results' do
         on(agent, config_content_command) do | result |
           assert_match(/0/, get_xml_value("//sources/source[@id='chocolatey']/@priority", result.output).to_s, 'Priority change did not match')
+        end
+      end
+    end
+  end
+
+  context 'MODULES-4418 Remove Bypass Proxy from an Existing Source' do
+
+    before(:all) do
+      backup_config
+    end
+
+    after(:all) do
+      reset_config
+    end
+
+    windows_agents.each do | agent |
+      chocolatey_src = <<-PP
+        chocolateysource {'chocolatey':
+          ensure   => present,
+          location => 'https://chocolatey.org/api/v2',
+          bypass_proxy => true,
+        }
+      PP
+
+      chocolatey_src_remove = <<-PP
+        chocolateysource {'chocolatey':
+          ensure   => present,
+          location => 'https://chocolatey.org/api/v2',
+        }
+      PP
+
+      it 'Should apply a manifest' do
+        execute_manifest_on(agent, chocolatey_src, :catch_failures => true)
+      end
+
+      it 'Should verify setup' do
+        on(agent, config_content_command) do | result |
+          assert_match(/true/, get_xml_value("//sources/source[@id='chocolatey']/@bypassProxy", result.output).to_s, 'Bypass Proxy did not match')
+        end
+      end
+
+      it 'Should apply remove manifest' do
+        execute_manifest_on(agent, chocolatey_src_remove, :catch_failures => true)
+      end
+
+      it 'Should verify results' do
+        on(agent, config_content_command) do | result |
+          assert_match(/false/, get_xml_value("//sources/source[@id='chocolatey']/@bypassProxy", result.output).to_s, 'Bypass Proxy change did not match')
         end
       end
     end

--- a/spec/unit/puppet/provider/chocolateysource/windows_spec.rb
+++ b/spec/unit/puppet/provider/chocolateysource/windows_spec.rb
@@ -55,9 +55,11 @@ describe provider do
   EOT
   }
 
-  let (:newer_choco_version) {'0.9.10.0'}
+  let (:newer_choco_version) {'0.10.5'}
   let (:minimum_supported_version_priority) {'0.9.9.9'}
   let (:last_unsupported_version_priority) {'0.9.9.8'}
+  let (:minimum_supported_version_bypass_proxy) {'0.10.4'}
+  let (:last_unsupported_version_bypass_proxy) {'0.10.3'}
   let (:minimum_supported_version) {'0.9.9.0'}
   let (:last_unsupported_version) {'0.9.8.33'}
 
@@ -142,6 +144,15 @@ describe provider do
         resource[:password] = 'api123-456-243 d123'
       end
     end
+
+    context ":bypass_proxy" do
+      it "should accept 'true' as a string" do
+        resource[:bypass_proxy] = 'true'
+      end
+      it "should accept 'true as a boolean'" do
+        resource[:bypass_proxy] = true
+      end
+    end
   end
 
   context "self.get_sources" do
@@ -196,15 +207,17 @@ describe provider do
     element_priority = "10"
     element_user = "thisguy"
     element_password = "super/encrypted+value=="
+    element_bypass_proxy = "true"
 
 
     before :each do
-      element.add_attributes( { "id"        => element_id,
-                                "value"     => element_value,
-                                "disabled"  => element_disabled,
-                                "priority"  => element_priority,
-                                "user"      => element_user,
-                                "password"  => element_password
+      element.add_attributes( { "id"          => element_id,
+                                "value"       => element_value,
+                                "disabled"    => element_disabled,
+                                "priority"    => element_priority,
+                                "user"        => element_user,
+                                "password"    => element_password,
+                                "bypassProxy" => element_bypass_proxy,
                               } )
     end
 
@@ -220,6 +233,7 @@ describe provider do
       source[:priority].must eq element_priority
       source[:user].must eq element_user
       source[:ensure].must eq :present
+      source[:bypass_proxy].must eq element_bypass_proxy
     end
 
     it "should convert a bare bones element to a source" do
@@ -227,6 +241,7 @@ describe provider do
       element.delete_attribute('priority')
       element.delete_attribute('user')
       element.delete_attribute('password')
+      element.delete_attribute('bypassProxy')
 
       source = provider.get_source(element)
 
@@ -293,6 +308,33 @@ describe provider do
 
       PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(minimum_supported_version)
       Puppet.expects(:warning).never
+
+      resource.provider.validate
+    end
+
+    it "should not warn on bypass_proxy when choco version is newer than the minimum supported version" do
+      resource[:bypass_proxy] = true
+
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(newer_choco_version)
+      Puppet.expects(:warning).never
+
+      resource.provider.validate
+    end
+
+    it "should not warn on bypass_proxy when choco version is the minimum supported version" do
+      resource[:bypass_proxy] = true
+
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(minimum_supported_version_bypass_proxy)
+      Puppet.expects(:warning).never
+
+      resource.provider.validate
+    end
+
+    it "should warn on bypass_proxy when choco version is less than the minimum supported version" do
+      resource[:bypass_proxy] = true
+
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(last_unsupported_version_bypass_proxy)
+      Puppet.expects(:warning).with("Chocolatey is unable to specify bypassing system proxy for sources when version is less than 0.10.4. The value you set will be ignored.")
 
       resource.provider.validate
     end
@@ -374,6 +416,7 @@ describe provider do
     resource_priority = 10
     resource_user = "thatguy"
     resource_password = "secrets!"
+    resource_bypass_proxy = :true
 
     before :each do
       PuppetX::Chocolatey::ChocolateyCommon.expects(:set_env_chocolateyinstall).at_most_once
@@ -407,6 +450,7 @@ describe provider do
       resource[:priority] = resource_priority
       resource[:user] = resource_user
       resource[:password] = resource_password
+      resource[:bypass_proxy] = resource_bypass_proxy
 
       PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(newer_choco_version)
       Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
@@ -415,6 +459,7 @@ describe provider do
                                                       '--source', resource_location,
                                                       '--user', resource_user,
                                                       '--password', resource_password,
+                                                      '--bypass-proxy',
                                                       '--priority', resource_priority,
                                                      ])
 
@@ -434,6 +479,26 @@ describe provider do
                                                       '--name', resource_name,
                                                       '--source', resource_location,
                                                       '--priority', resource_priority,
+                                                     ])
+
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'source', 'enable',
+                                                      '--name', resource_name
+                                                     ])
+
+      resource.flush
+    end
+
+    it "should set bypass_proxy when present" do
+      resource[:bypass_proxy] = resource_bypass_proxy
+
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(newer_choco_version)
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'source', 'add',
+                                                      '--name', resource_name,
+                                                      '--source', resource_location,
+                                                      '--bypass-proxy',
+                                                      '--priority', 0,
                                                      ])
 
       Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
@@ -504,6 +569,65 @@ describe provider do
       Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
                                                       'source', 'enable',
                                                       '--name', resource_name
+                                                     ])
+
+      resource.flush
+    end
+
+    it "should not set bypass_proxy when choco version is less than the minimum supported version" do
+      resource[:bypass_proxy] = resource_bypass_proxy
+
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(last_unsupported_version_bypass_proxy)
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'source', 'add',
+                                                      '--name', resource_name,
+                                                      '--source', resource_location,
+                                                      '--priority', 0,
+                                                     ])
+
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'source', 'enable',
+                                                      '--name', resource_name,
+                                                     ])
+
+      resource.flush
+    end
+
+    it "should set bypass_proxy when choco version is newer than the minimum supported version" do
+      resource[:bypass_proxy] = resource_bypass_proxy
+
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(newer_choco_version)
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'source', 'add',
+                                                      '--name', resource_name,
+                                                      '--source', resource_location,
+                                                      '--bypass-proxy',
+                                                      '--priority', 0,
+                                                     ])
+
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'source', 'enable',
+                                                      '--name', resource_name,
+                                                     ])
+
+      resource.flush
+    end
+
+    it "should set bypass_proxy when choco version is the minimum supported version" do
+      resource[:bypass_proxy] = resource_bypass_proxy
+
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(minimum_supported_version_bypass_proxy)
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'source', 'add',
+                                                      '--name', resource_name,
+                                                      '--source', resource_location,
+                                                      '--bypass-proxy',
+                                                      '--priority', 0,
+                                                     ])
+
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'source', 'enable',
+                                                      '--name', resource_name,
                                                      ])
 
       resource.flush

--- a/spec/unit/puppet/type/chocolateysource_spec.rb
+++ b/spec/unit/puppet/type/chocolateysource_spec.rb
@@ -34,6 +34,20 @@ describe Puppet::Type.type(:chocolateysource) do
     end
   end
 
+  #boolean values
+  ['bypass_proxy'].each do |param|
+    context "parameter :#{param}" do
+      let (:param_symbol) { param.to_sym }
+
+      it "should accept any valid boolean value" do
+        resource[param_symbol] = true
+        resource[param_symbol] = 'true'
+        resource[param_symbol] = false
+        resource[param_symbol] = 'false'
+      end
+    end
+  end
+
   #numeric values
   ['priority'].each do |param|
     context "parameter :#{param}" do


### PR DESCRIPTION
Prior to this commit the `chocolateysource` type and provider did
not support the option to specify the `--bypass-proxy` flag when
managing a source. This option causes Chocolatey to ignore any
system proxies and was introduced in Chocolatey `0.10.4`.

This commit adds the `bypass_proxy` property to the type and
provider of `chocolateysource` to ensure that this property
can be configured on versions which support it.

This commit also updates the README documentation and CHANGELOG,
as well as providing new unit and acceptance tests and updating
any unit and acceptance tests which should include the new
setting.

As new features are added which depend on particular versions of
Chocolatey, it may be useful to refactor the tests and provider
to manage the addition of such features with less duplicated
code, but that is considered out-of-scope for this improvement.