### PR TITLE
(MAINT) Fix CI download logic

### DIFF
--- a/spec/support/utilities/helpers.rb
+++ b/spec/support/utilities/helpers.rb
@@ -3,6 +3,9 @@ CHOCOLATEY_LATEST_INFO_URL = "https://artifactory.delivery.puppetlabs.net/artifa
 def get_latest_chocholatey_download_url
   uri = URI.parse(CHOCOLATEY_LATEST_INFO_URL)
 
+  # For some reason, the first time you hit the URL it gives you the wrong version.
+  # The second time you hit the URL it gives you the latest version.
+  response = Net::HTTP.get_response(uri)
   response = Net::HTTP.get_response(uri)
   xml_str = Nokogiri::XML(response.body)
 


### PR DESCRIPTION
For some reason when hitting the artifactory URL for the first time
the wrong package version is returned. This is true in the browser,
so it is not a problem in the code path.

This commit adds logic to the helper function to hit the URL twice
in order to force the correct version to be returned.