### PR TITLE
(MODULES-5898) add admin_only to chocolateysource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 ### Added
 
 - Configuration option for `chocolateysource` to allow bypassing any system-configured proxies ([MODULES-4418](https://tickets.puppetlabs.com/browse/MODULES-4418)).
+- Configuration option for `chocolateysource` to make a source visible only to Windows users in the Administrators group ([MODULES-5898](https://tickets.puppetlabs.com/browse/MODULES-5898)).
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -685,6 +685,15 @@ Specifies an option to specify whether this source should explicitly bypass any 
 Requires at least Chocolatey v0.10.4.
 Defaults to `false`.
 
+#### `admin_only`
+
+(**Property**: This parameter represents a concrete state on the target system.)
+
+Specifies an option to specify whether this source should visible to Windows user accounts in the Administrators group only.
+
+Requires Chocolatey for Business (C4B) v1.12.2+ and at least Chocolatey v0.10.8 for the setting to be respected.
+Defaults to false.
+
 ### ChocolateyFeature
 
 Allows managing features for Chocolatey. Features are configurations that

--- a/lib/puppet/provider/chocolateysource/windows.rb
+++ b/lib/puppet/provider/chocolateysource/windows.rb
@@ -12,6 +12,7 @@ Puppet::Type.type(:chocolateysource).provide(:windows) do
   MINIMUM_SUPPORTED_CHOCO_VERSION = '0.9.9.0'
   MINIMUM_SUPPORTED_CHOCO_VERSION_PRIORITY = '0.9.9.9'
   MINIMUM_SUPPORTED_CHOCO_VERSION_BYPASS_PROXY = '0.10.4'
+  MINIMUM_SUPPORTED_CHOCO_VERSION_ADMIN_ONLY   = '0.10.8'
 
   commands :chocolatey => PuppetX::Chocolatey::ChocolateyCommon.chocolatey_command
 
@@ -66,6 +67,9 @@ Puppet::Type.type(:chocolateysource).provide(:windows) do
 
     source[:bypass_proxy] = false
     source[:bypass_proxy] = element.attributes['bypassProxy'].downcase if element.attributes['bypassProxy']
+
+    source[:admin_only] = false
+    source[:admin_only] = element.attributes['adminOnly'].downcase if element.attributes['adminOnly']
 
     source[:user] = ''
     source[:user] = element.attributes['user'].downcase if element.attributes['user']
@@ -128,6 +132,11 @@ Puppet::Type.type(:chocolateysource).provide(:windows) do
     if choco_version < Gem::Version.new(MINIMUM_SUPPORTED_CHOCO_VERSION_BYPASS_PROXY) && resource[:bypass_proxy] && resource[:bypass_proxy] != :false
       Puppet.warning("Chocolatey is unable to specify bypassing system proxy for sources when version is less than #{MINIMUM_SUPPORTED_CHOCO_VERSION_BYPASS_PROXY}. The value you set will be ignored.")
     end
+
+    if choco_version < Gem::Version.new(MINIMUM_SUPPORTED_CHOCO_VERSION_ADMIN_ONLY) && resource[:admin_only] && resource[:admin_only] != :false
+      Puppet.warning("Chocolatey is unable to specify administrator only visibility for sources when version is less than #{MINIMUM_SUPPORTED_CHOCO_VERSION_ADMIN_ONLY}. The value you set will be ignored.")
+    end
+
     # location is always filled in with puppet resource, but
     # resource[:location] is always empty (because it has a different
     # code path where validation occurs before all properties/params
@@ -178,6 +187,10 @@ Puppet::Type.type(:chocolateysource).provide(:windows) do
       choco_gem_version = Gem::Version.new(PuppetX::Chocolatey::ChocolateyCommon.choco_version)
       if choco_gem_version >= Gem::Version.new(MINIMUM_SUPPORTED_CHOCO_VERSION_BYPASS_PROXY)
         args << '--bypass-proxy' if resource[:bypass_proxy].to_s == 'true'
+      end
+
+      if choco_gem_version >= Gem::Version.new(MINIMUM_SUPPORTED_CHOCO_VERSION_ADMIN_ONLY)
+        args << '--admin-only' if resource[:admin_only].to_s == 'true'
       end
 
       if choco_gem_version >= Gem::Version.new(MINIMUM_SUPPORTED_CHOCO_VERSION_PRIORITY)

--- a/lib/puppet/type/chocolateysource.rb
+++ b/lib/puppet/type/chocolateysource.rb
@@ -122,6 +122,23 @@ Puppet::Type.newtype(:chocolateysource) do
     end
   end
 
+  newproperty(:admin_only, :boolean => true) do
+    desc "Option to specify whether this source should
+      visible to Windows user accounts in the Administrators
+      group only.
+
+      Requires Chocolatey for Business (C4B) v1.12.2+ and at
+      least Chocolatey v0.10.8 for the setting to be respected.
+      Defaults to false."
+    
+    newvalues(:true, :false)
+    defaultto(:false)
+
+    munge do |value|
+      resource.munge_boolean(value)
+    end
+  end
+
   validate do
     if (!self[:user].nil? && self[:user].strip != '' && (self[:password].nil? || self[:password] == '')) || ((self[:user].nil? || self[:user].strip == '') && !self[:password].nil? && self[:password] != '')
       raise ArgumentError, "If specifying user/password, you must specify both values."

--- a/spec/unit/puppet/provider/chocolateysource/windows_spec.rb
+++ b/spec/unit/puppet/provider/chocolateysource/windows_spec.rb
@@ -55,11 +55,13 @@ describe provider do
   EOT
   }
 
-  let (:newer_choco_version) {'0.10.5'}
+  let (:newer_choco_version) {'0.10.9'}
   let (:minimum_supported_version_priority) {'0.9.9.9'}
   let (:last_unsupported_version_priority) {'0.9.9.8'}
   let (:minimum_supported_version_bypass_proxy) {'0.10.4'}
   let (:last_unsupported_version_bypass_proxy) {'0.10.3'}
+  let (:minimum_supported_version_admin_only) {'0.10.8'}
+  let (:last_unsupported_version_admin_only) {'0.10.7'}
   let (:minimum_supported_version) {'0.9.9.0'}
   let (:last_unsupported_version) {'0.9.8.33'}
 
@@ -153,6 +155,15 @@ describe provider do
         resource[:bypass_proxy] = true
       end
     end
+
+    context ":admin_only" do
+      it "should accept 'true' as a string" do
+        resource[:admin_only] = 'true'
+      end
+      it "should accept 'true as a boolean'" do
+        resource[:admin_only] = true
+      end
+    end
   end
 
   context "self.get_sources" do
@@ -208,6 +219,7 @@ describe provider do
     element_user = "thisguy"
     element_password = "super/encrypted+value=="
     element_bypass_proxy = "true"
+    element_admin_only = "true"
 
 
     before :each do
@@ -218,6 +230,7 @@ describe provider do
                                 "user"        => element_user,
                                 "password"    => element_password,
                                 "bypassProxy" => element_bypass_proxy,
+                                "adminOnly"   => element_admin_only,
                               } )
     end
 
@@ -234,6 +247,7 @@ describe provider do
       source[:user].must eq element_user
       source[:ensure].must eq :present
       source[:bypass_proxy].must eq element_bypass_proxy
+      source[:admin_only].must eq element_admin_only
     end
 
     it "should convert a bare bones element to a source" do
@@ -242,6 +256,7 @@ describe provider do
       element.delete_attribute('user')
       element.delete_attribute('password')
       element.delete_attribute('bypassProxy')
+      element.delete_attribute('adminOnly')
 
       source = provider.get_source(element)
 
@@ -339,6 +354,33 @@ describe provider do
       resource.provider.validate
     end
 
+    it "should not warn on admin_only when choco version is newer than the minimum supported version" do
+      resource[:admin_only] = true
+
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(newer_choco_version)
+      Puppet.expects(:warning).never
+
+      resource.provider.validate
+    end
+
+    it "should not warn on admin_only when choco version is the minimum supported version" do
+      resource[:admin_only] = true
+
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(minimum_supported_version_admin_only)
+      Puppet.expects(:warning).never
+
+      resource.provider.validate
+    end
+
+    it "should warn on admin_only when choco version is less than the minimum supported version" do
+      resource[:admin_only] = true
+
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(last_unsupported_version_admin_only)
+      Puppet.expects(:warning).with("Chocolatey is unable to specify administrator only visibility for sources when version is less than 0.10.8. The value you set will be ignored.")
+
+      resource.provider.validate
+    end
+
     it "should not warn if priority is not set" do
       PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(newer_choco_version)
       Puppet.expects(:warning).never
@@ -417,6 +459,7 @@ describe provider do
     resource_user = "thatguy"
     resource_password = "secrets!"
     resource_bypass_proxy = :true
+    resource_admin_only = :true
 
     before :each do
       PuppetX::Chocolatey::ChocolateyCommon.expects(:set_env_chocolateyinstall).at_most_once
@@ -451,6 +494,7 @@ describe provider do
       resource[:user] = resource_user
       resource[:password] = resource_password
       resource[:bypass_proxy] = resource_bypass_proxy
+      resource[:admin_only] = resource_admin_only
 
       PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(newer_choco_version)
       Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
@@ -460,6 +504,7 @@ describe provider do
                                                       '--user', resource_user,
                                                       '--password', resource_password,
                                                       '--bypass-proxy',
+                                                      '--admin-only',
                                                       '--priority', resource_priority,
                                                      ])
 
@@ -498,6 +543,26 @@ describe provider do
                                                       '--name', resource_name,
                                                       '--source', resource_location,
                                                       '--bypass-proxy',
+                                                      '--priority', 0,
+                                                     ])
+
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'source', 'enable',
+                                                      '--name', resource_name
+                                                     ])
+
+      resource.flush
+    end
+
+    it "should set admin_only when present" do
+      resource[:admin_only] = resource_admin_only
+
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(newer_choco_version)
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'source', 'add',
+                                                      '--name', resource_name,
+                                                      '--source', resource_location,
+                                                      '--admin-only',
                                                       '--priority', 0,
                                                      ])
 
@@ -622,6 +687,65 @@ describe provider do
                                                       '--name', resource_name,
                                                       '--source', resource_location,
                                                       '--bypass-proxy',
+                                                      '--priority', 0,
+                                                     ])
+
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'source', 'enable',
+                                                      '--name', resource_name,
+                                                     ])
+
+      resource.flush
+    end
+
+    it "should not set admin_only when choco version is less than the minimum supported version" do
+      resource[:admin_only] = resource_admin_only
+
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(last_unsupported_version_admin_only)
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'source', 'add',
+                                                      '--name', resource_name,
+                                                      '--source', resource_location,
+                                                      '--priority', 0,
+                                                     ])
+
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'source', 'enable',
+                                                      '--name', resource_name,
+                                                     ])
+
+      resource.flush
+    end
+
+    it "should set admin_only when choco version is newer than the minimum supported version" do
+      resource[:admin_only] = resource_admin_only
+
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(newer_choco_version)
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'source', 'add',
+                                                      '--name', resource_name,
+                                                      '--source', resource_location,
+                                                      '--admin-only',
+                                                      '--priority', 0,
+                                                     ])
+
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'source', 'enable',
+                                                      '--name', resource_name,
+                                                     ])
+
+      resource.flush
+    end
+
+    it "should set admin_only when choco version is the minimum supported version" do
+      resource[:admin_only] = resource_admin_only
+
+      PuppetX::Chocolatey::ChocolateyCommon.expects(:choco_version).returns(minimum_supported_version_admin_only)
+      Puppet::Util::Execution.expects(:execute).with([provider.command(:chocolatey),
+                                                      'source', 'add',
+                                                      '--name', resource_name,
+                                                      '--source', resource_location,
+                                                      '--admin-only',
                                                       '--priority', 0,
                                                      ])
 

--- a/spec/unit/puppet/type/chocolateysource_spec.rb
+++ b/spec/unit/puppet/type/chocolateysource_spec.rb
@@ -35,7 +35,7 @@ describe Puppet::Type.type(:chocolateysource) do
   end
 
   #boolean values
-  ['bypass_proxy'].each do |param|
+  ['bypass_proxy','admin_only'].each do |param|
     context "parameter :#{param}" do
       let (:param_symbol) { param.to_sym }
 


### PR DESCRIPTION
Prior to this commit the `chocolateysource` type and provider did
not support the option to specify the `--admin-only` flag when
managing a source. This option causes Chocolatey to markthe source
as visible only to admins  and was introduced in Chocolatey `0.10.8`.

This commit adds the `admin_only` property to the type and
provider of `chocolateysource` to ensure that this property
can be configured on versions which support it.

This commit also updates the README documentation and CHANGELOG,
as well as providing new unit and acceptance tests and updating
any unit and acceptance tests which should include the new
setting.