### PR TITLE
(MODULES-5897) Add allow_self_service to chocolateysource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 
 - Configuration option for `chocolateysource` to allow bypassing any system-configured proxies ([MODULES-4418](https://tickets.puppetlabs.com/browse/MODULES-4418)).
 - Configuration option for `chocolateysource` to make a source visible only to Windows users in the Administrators group ([MODULES-5898](https://tickets.puppetlabs.com/browse/MODULES-5898)).
+- Configuration option for `chocolateysource` to make a source usable with Chocolatey Self Service ([MODULES-5897](https://tickets.puppetlabs.com/browse/MODULES-5897))
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -694,6 +694,17 @@ Specifies an option to specify whether this source should visible to Windows use
 Requires Chocolatey for Business (C4B) v1.12.2+ and at least Chocolatey v0.10.8 for the setting to be respected.
 Defaults to false.
 
+#### `allow_self_service`
+
+(**Property**: This parameter represents a concrete state on the target system.)
+
+Specifies whether this source should be allowed to be used with Chocolatey Self Service.
+
+Requires Chocolatey for Business (C4B) v1.10.0+ with the feature `useBackgroundServiceWithSelfServiceSourcesOnly` turned on in order to be respected.
+Also requires at least Chocolatey v0.10.4 for the setting to be enabled.
+
+Defaults to `false`.
+
 ### ChocolateyFeature
 
 Allows managing features for Chocolatey. Features are configurations that

--- a/lib/puppet/provider/chocolateysource/windows.rb
+++ b/lib/puppet/provider/chocolateysource/windows.rb
@@ -12,6 +12,7 @@ Puppet::Type.type(:chocolateysource).provide(:windows) do
   MINIMUM_SUPPORTED_CHOCO_VERSION = '0.9.9.0'
   MINIMUM_SUPPORTED_CHOCO_VERSION_PRIORITY = '0.9.9.9'
   MINIMUM_SUPPORTED_CHOCO_VERSION_BYPASS_PROXY = '0.10.4'
+  MINIMUM_SUPPORTED_CHOCO_VERSION_ALLOW_SELF_SERVICE = '0.10.4'
   MINIMUM_SUPPORTED_CHOCO_VERSION_ADMIN_ONLY   = '0.10.8'
 
   commands :chocolatey => PuppetX::Chocolatey::ChocolateyCommon.chocolatey_command
@@ -70,6 +71,9 @@ Puppet::Type.type(:chocolateysource).provide(:windows) do
 
     source[:admin_only] = false
     source[:admin_only] = element.attributes['adminOnly'].downcase if element.attributes['adminOnly']
+
+    source[:allow_self_service] = false
+    source[:allow_self_service] = element.attributes['selfService'].downcase if element.attributes['selfService']
 
     source[:user] = ''
     source[:user] = element.attributes['user'].downcase if element.attributes['user']
@@ -133,6 +137,10 @@ Puppet::Type.type(:chocolateysource).provide(:windows) do
       Puppet.warning("Chocolatey is unable to specify bypassing system proxy for sources when version is less than #{MINIMUM_SUPPORTED_CHOCO_VERSION_BYPASS_PROXY}. The value you set will be ignored.")
     end
 
+    if choco_version < Gem::Version.new(MINIMUM_SUPPORTED_CHOCO_VERSION_ALLOW_SELF_SERVICE) && resource[:allow_self_service] && resource[:allow_self_service] != :false
+      Puppet.warning("Chocolatey is unable to specify self-service for sources when version is less than #{MINIMUM_SUPPORTED_CHOCO_VERSION_ALLOW_SELF_SERVICE}. The value you set will be ignored.")
+    end
+
     if choco_version < Gem::Version.new(MINIMUM_SUPPORTED_CHOCO_VERSION_ADMIN_ONLY) && resource[:admin_only] && resource[:admin_only] != :false
       Puppet.warning("Chocolatey is unable to specify administrator only visibility for sources when version is less than #{MINIMUM_SUPPORTED_CHOCO_VERSION_ADMIN_ONLY}. The value you set will be ignored.")
     end
@@ -187,6 +195,10 @@ Puppet::Type.type(:chocolateysource).provide(:windows) do
       choco_gem_version = Gem::Version.new(PuppetX::Chocolatey::ChocolateyCommon.choco_version)
       if choco_gem_version >= Gem::Version.new(MINIMUM_SUPPORTED_CHOCO_VERSION_BYPASS_PROXY)
         args << '--bypass-proxy' if resource[:bypass_proxy].to_s == 'true'
+      end
+
+      if choco_gem_version >= Gem::Version.new(MINIMUM_SUPPORTED_CHOCO_VERSION_ALLOW_SELF_SERVICE)
+        args << '--allow-self-service' if resource[:allow_self_service] == :true
       end
 
       if choco_gem_version >= Gem::Version.new(MINIMUM_SUPPORTED_CHOCO_VERSION_ADMIN_ONLY)

--- a/lib/puppet/type/chocolateysource.rb
+++ b/lib/puppet/type/chocolateysource.rb
@@ -139,6 +139,25 @@ Puppet::Type.newtype(:chocolateysource) do
     end
   end
 
+  newproperty(:allow_self_service, :boolean => true) do
+    desc "Option to specify whether this source should be
+      allowed to be used with Chocolatey Self Service.
+
+      Requires Chocolatey for Business (C4B) v1.10.0+ with the
+      feature useBackgroundServiceWithSelfServiceSourcesOnly
+      turned on in order to be respected.
+      Also requires at least Chocolatey v0.10.4 for the setting
+      to be enabled.
+      Defaults to false."
+    
+    newvalues(:true, :false)
+    defaultto(:false)
+
+    munge do |value|
+      resource.munge_boolean(value)
+    end
+  end
+
   validate do
     if (!self[:user].nil? && self[:user].strip != '' && (self[:password].nil? || self[:password] == '')) || ((self[:user].nil? || self[:user].strip == '') && !self[:password].nil? && self[:password] != '')
       raise ArgumentError, "If specifying user/password, you must specify both values."

--- a/spec/acceptance/sources_spec.rb
+++ b/spec/acceptance/sources_spec.rb
@@ -65,6 +65,38 @@ describe 'Chocolatey Source' do
     end
   end
 
+  context 'MODULES-5897 - Add Self Service to an Existing Source' do
+
+    before(:all) do
+      backup_config
+    end
+
+    after(:all) do
+      reset_config
+    end
+
+    windows_agents.each do | agent |
+
+      it 'Should Apply the Manifest' do
+        chocolatey_src = <<-PP
+          chocolateysource {'chocolatey':
+            ensure             => present,
+            location           => 'https://chocolatey.org/api/v2',
+            allow_self_service => true,
+          }
+        PP
+
+        execute_manifest_on(agent, chocolatey_src, :catch_failures => true)
+      end
+
+      it 'Should now mark the source as usable for self-service' do
+        on(agent, config_content_command) do |result|
+          assert_match(/true/, get_xml_value("//sources/source[@id='chocolatey']/@selfService", result.output).to_s, 'Self Service did not match')
+        end
+      end
+    end
+  end
+
   context 'MODULES-5898 - Add Admin Only to an Existing Source' do
 
     before(:all) do
@@ -112,13 +144,14 @@ describe 'Chocolatey Source' do
       it 'Should Apply the Manifest' do
         chocolatey_src = <<-PP
           chocolateysource {'test':
-            ensure       => present,
-            location     => 'c:\\packages',
-            priority     => 2,
-            user         => 'bob',
-            password     => 'yes',
-            bypass_proxy => true,
-            admin_only   => true,
+            ensure             => present,
+            location           => 'c:\\packages',
+            priority           => 2,
+            user               => 'bob',
+            password           => 'yes',
+            bypass_proxy       => true,
+            allow_self_service => true,
+            admin_only         => true,
           }
         PP
 
@@ -133,6 +166,7 @@ describe 'Chocolatey Source' do
           assert_match(/.+/, get_xml_value("//sources/source[@id='test']/@password", result.output).to_s, 'Password was not saved')
           assert_match(/false/, get_xml_value("//sources/source[@id='test']/@disabled", result.output).to_s, 'Disabled did not match')
           assert_match(/true/, get_xml_value("//sources/source[@id='test']/@bypassProxy", result.output).to_s, 'Bypass Proxy did not match')
+          assert_match(/true/, get_xml_value("//sources/source[@id='test']/@selfService", result.output).to_s, 'Self Service did not match')
           assert_match(/true/, get_xml_value("//sources/source[@id='test']/@adminOnly", result.output).to_s, 'Admin Only did not match')
         end
       end
@@ -327,6 +361,55 @@ describe 'Chocolatey Source' do
       it 'Should verify results' do
         on(agent, config_content_command) do | result |
           assert_match(/false/, get_xml_value("//sources/source[@id='chocolatey']/@bypassProxy", result.output).to_s, 'Bypass Proxy change did not match')
+        end
+      end
+    end
+  end
+
+  context 'MODULES-5897 - Change Existing Self Service Setting' do
+
+    before(:all) do
+      backup_config
+    end
+    
+    after(:all) do
+      reset_config
+    end
+
+    windows_agents.each do | agent |
+      it 'Should apply a manifest to set allow_self_service' do
+        chocolatey_src = <<-PP
+          chocolateysource {'chocolatey':
+            ensure             => present,
+            location           => 'https://chocolatey.org/api/v2',
+            allow_self_service => true,
+          }
+        PP
+
+        execute_manifest_on(agent, chocolatey_src, :catch_failures => true)
+      end
+
+      it 'Should verify the setup was added' do
+        on(agent, config_content_command) do | result |
+          assert_match(/true/, get_xml_value("//sources/source[@id='chocolatey']/@selfService", result.output).to_s, 'Self Service setup did not match')
+        end
+      end
+
+      it 'Should apply a manifest to set allow_self_service to false' do
+        chocolatey_src_change = <<-PP
+          chocolateysource {'chocolatey':
+            ensure             => present,
+            location           => 'https://chocolatey.org/api/v2',
+            allow_self_service => false,
+          }
+        PP
+
+        execute_manifest_on(agent, chocolatey_src_change, :catch_failures => true)
+      end
+
+      it 'Should verify results' do
+        on(agent, config_content_command) do | result |
+          assert_match(/false/, get_xml_value("//sources/source[@id='chocolatey']/@selfService", result.output).to_s, 'Self Service change did not match')
         end
       end
     end
@@ -749,6 +832,54 @@ describe 'Chocolatey Source' do
       it 'Should verify results' do
         on(agent, config_content_command) do | result |
           assert_match(/false/, get_xml_value("//sources/source[@id='chocolatey']/@bypassProxy", result.output).to_s, 'Bypass Proxy change did not match')
+        end
+      end
+    end
+  end
+
+  context 'MODULES-5897 Remove Self Service from an Existing Source' do
+
+    before(:all) do
+      backup_config
+    end
+
+    after(:all) do
+      reset_config
+    end
+
+    windows_agents.each do | agent |
+      chocolatey_src = <<-PP
+        chocolateysource {'chocolatey':
+          ensure             => present,
+          location           => 'https://chocolatey.org/api/v2',
+          allow_self_service => true,
+        }
+      PP
+
+      chocolatey_src_remove = <<-PP
+        chocolateysource {'chocolatey':
+          ensure   => present,
+          location => 'https://chocolatey.org/api/v2',
+        }
+      PP
+
+      it 'Should apply a manifest' do
+        execute_manifest_on(agent, chocolatey_src, :catch_failures => true)
+      end
+
+      it 'Should verify setup' do
+        on(agent, config_content_command) do | result |
+          assert_match(/true/, get_xml_value("//sources/source[@id='chocolatey']/@selfService", result.output).to_s, 'Self Service did not match')
+        end
+      end
+
+      it 'Should apply remove manifest' do
+        execute_manifest_on(agent, chocolatey_src_remove, :catch_failures => true)
+      end
+
+      it 'Should verify results' do
+        on(agent, config_content_command) do | result |
+          assert_match(/false/, get_xml_value("//sources/source[@id='chocolatey']/@selfService", result.output).to_s, 'Self Service change did not match')
         end
       end
     end

--- a/spec/unit/puppet/type/chocolateysource_spec.rb
+++ b/spec/unit/puppet/type/chocolateysource_spec.rb
@@ -35,7 +35,7 @@ describe Puppet::Type.type(:chocolateysource) do
   end
 
   #boolean values
-  ['bypass_proxy','admin_only'].each do |param|
+  ['bypass_proxy','admin_only','allow_self_service'].each do |param|
     context "parameter :#{param}" do
       let (:param_symbol) { param.to_sym }
 


### PR DESCRIPTION
Prior to this commit the `chocolateysource` type and provider did
not support the option to specify the `--allow-self-service` flag
when managing a source. This option causes Chocolatey to mark the
source as being usable with the C4B Self-Service feature as of
C4B v1.10.0. It requires Chocolatey 0.10.4+ to set this option.

This commit adds the `allow_self_service` property to the type and
provider of `chocolateysource` to ensure that this property
can be configured on versions which support it.

This commit also updates the README documentation and CHANGELOG,
as well as providing new unit and acceptance tests and updating
any unit and acceptance tests which should include the new
setting.