### PR TITLE
(MODULES-7042) Document chocolatey_version

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,7 +533,7 @@ alternative method to pass args if you have 0.9.8.x and below.
 
 ### Facts
 
-* `chocolateyversion` - The version of the installed Chocolatey client (could also be provided by class parameter `chocolatey_version`).
+* `chocolateyversion` - The version of the installed Chocolatey client (could also be informationally provided by class parameter `chocolatey_version`).
 * `choco_install_path` - The location of the installed Chocolatey client (could also be provided by class parameter `choco_install_location`).
 
 ### Types/Providers
@@ -783,6 +783,10 @@ Specifies whether to use the built-in shell or allow the installer to download 7
 ##### `choco_install_timeout_seconds`
 
 Specifies how long in seconds should be allowed for the install of Chocolatey (including .NET Framework 4 if necessary). Valid options: Number. Default: `1500` (25 minutes).
+
+##### `chocolatey_install_version`
+
+This is an **informational** parameter to tell Chocolatey what version to expect and to pre-load features with, falls back to the value of the `chocolateyversion` fact.
 
 ##### `chocolatey_download_url`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -57,8 +57,9 @@
 #   package. Defaults to `true`. Setting is ignored in Chocolatey v0.9.10+.
 # @param [Boolean] log_output Log output from the installer. Defaults to
 #   `false`.
-# @param [String] chocolatey_version chocolatey version, falls back to
-#   `$::chocolateyversion`.
+# @param [String] chocolatey_version - **Informational** parameter to tell
+#   Chocolatey what version to expect and to pre-load features with, falls
+#   back to `$::chocolateyversion`.
 # @param install_proxy Proxy server to use to use for installation of chocolatey itself or
 #   `undef` to not use a proxy
 class chocolatey (


### PR DESCRIPTION
The existing documentation for the `chocolatey_version` parameter
of the `chocolatey` class is only in the init.pp file and briefly
mentioned in the documentation for the `chocolateyversion` fact.

None of these documentation sources cover that the parameter is
an optional informational flag to send to the class to help it
decide what behaviors to follow during execution.

A straight reading of the parameter name in the context of the
class is that it should pin Chocolatey to a particular version.
It does not and was not meant to do this. While a future ticket
may add this functionality it is important that we document and
clarify the current usage and make it easier for users to
understand.

This commit adds that documentation both to the class itself and
to the README.