### PR TITLE
(MAINT) Fix broken state which causes CI to fail

### DIFF
--- a/lib/puppet/provider/package/chocolatey.rb
+++ b/lib/puppet/provider/package/chocolatey.rb
@@ -1,5 +1,6 @@
 require 'puppet/provider/package'
 require 'pathname'
+require 'rexml/document'
 require Pathname.new(__FILE__).dirname + '../../../' + 'puppet_x/chocolatey/chocolatey_install'
 
 Puppet::Type.type(:package).provide(:chocolatey, :parent => Puppet::Provider::Package) do


### PR DESCRIPTION
Prior to this commit the package provider code did not
explicitly include REXML, which it relies on. This was
missed during unit tests which explicitly require the
appropriate library and was only discovered during
acceptance testing.

This commit ensures the appropriate requires is in
place.