### PR TITLE
(MODULES-8047) Fix puppet resource chocolateyconfig

### DIFF
--- a/lib/puppet/type/chocolateyconfig.rb
+++ b/lib/puppet/type/chocolateyconfig.rb
@@ -70,10 +70,6 @@ Puppet::Type.newtype(:chocolateyconfig) do
   end
 
   validate do
-    if self[:ensure] != :absent
-      raise ArgumentError, "Unless ensure => absent, value is required." if self[:value].nil? || self[:value].empty?
-    end
-
     if provider.respond_to?(:validate)
       provider.validate
     end

--- a/spec/unit/puppet/provider/chocolateyconfig/windows_spec.rb
+++ b/spec/unit/puppet/provider/chocolateyconfig/windows_spec.rb
@@ -211,6 +211,30 @@ describe provider do
         resource.provider.validate
       }.to raise_error(Puppet::ResourceError, /Chocolatey version must be '0.9.10.0' to manage configuration values. Detected '#{last_unsupported_version}'/)
     end
+
+    it "should error when the property_hash is empty, :ensure is :present, and no :value is supplied" do
+      resource.delete(:value)
+
+      expect {
+        resource.provider.validate
+      }.to raise_error(ArgumentError, "Unless ensure => absent, value is required.")
+    end
+
+    it "should not error when the property_hash is defined, even if :ensure is :present and no :value is supplied" do
+      resource.delete(:value)
+      resource.provider.instance_variable_set("@property_hash", {:value => "something"})
+      resource.provider.validate
+    end
+
+    it "should not error when the property_hash is empty, :ensure is :present and a :value is supplied" do
+      resource.provider.validate
+    end
+
+    it "should not error when the property_hash is empty, :ensure is :absent and no :value is supplied" do
+      resource[:ensure] = :absent
+      resource.delete(:value)
+      resource.provider.validate
+    end
   end
 
   context ".flush" do

--- a/spec/unit/puppet/type/chocolateyconfig_spec.rb
+++ b/spec/unit/puppet/type/chocolateyconfig_spec.rb
@@ -77,27 +77,4 @@ describe Puppet::Type.type(:chocolateyconfig) do
     reqs[0].target.must == resource
   end
 
-  context ".validate" do
-    it "should pass when ensure => absent with no value" do
-      resource[:ensure] = :absent
-
-      resource.validate
-    end
-
-    it "should pass when ensure => present with a value" do
-      resource[:ensure] = :present
-      resource[:value] = 'yo'
-
-      resource.validate
-    end
-
-    it "should fail when ensure => present with no value" do
-      resource[:ensure] = :present
-
-      expect {
-        resource.validate
-      }.to raise_error(ArgumentError, /Unless ensure => absent, value is required/)
-    end
-  end
-
 end


### PR DESCRIPTION
Prior to this commit running `puppet resource chocolateyconfig` would
fail during the validation block which verified that no config items
were both :present *and* had an empty :value or were missing :value
altogether.

This is because Chocolatey represents a configuration item which is
using the defaults as an empty string. When collecting instances of
Chocolatey config items from the configuration file, it would find
the items, mark them as :present, and save them with a :value of "".

This would then fail the validation block.

During a `puppet apply` run the validation block is called before the
instances are fetched - and, therefore, before `@property_hash` is
populated. This allows us to distinguish between the two calls and error
on any declared resources which specify `:ensure` as `:present` but forget
to specify a `:value`.

This commit moves the validation logic from the type into the provider
in order to allow us to take advantage of the @property_hash information
during a `puppet resource` run.

This commit also updates the `get_config` method to treat any discovered
Chocolatey config item with an empty value as `:absent` - this matches
the behavior of `:ensure => :absent` which calls `choco config unset` -
this command replaces the existing value of a config item with an empty
string.

Now when returning the list of Chocolatey configs our model of them is
consistent, with `:absent` meaning that the configuration item is set
to the default.

This commit does not change the behavior of a `puppet apply` run.

This commit *does* include changes to the unit tests to reflect the
moving of the validation logic.