### PR TITLE
set default for install_location in params.pp

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,6 @@
 # chocolatey::params - Default parameters
 class chocolatey::params {
-  $install_location         = $::choco_install_path # default is C:\ProgramData\chocolatey
+  $install_location         = $::choco_install_location # default is C:\ProgramData\chocolatey
   $download_url             = 'https://chocolatey.org/api/v2/package/chocolatey/'
   $use_7zip                 = false
   $seven_zip_download_url   = 'https://chocolatey.org/7za.exe'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,6 @@
 # chocolatey::params - Default parameters
 class chocolatey::params {
-  $install_location         = $::choco_install_location # default is C:\ProgramData\chocolatey
+  $install_location         = 'C:\ProgramData\chocolatey'
   $download_url             = 'https://chocolatey.org/api/v2/package/chocolatey/'
   $use_7zip                 = false
   $seven_zip_download_url   = 'https://chocolatey.org/7za.exe'


### PR DESCRIPTION
a variable pointing to a variable pointing to a variable seems like a circular way of setting a default, I feel that you should set the default in params.pp (if you're using this design pattern) and override it from hiera data or using class resource-like statements as needed.