### PR TITLE
(MODULES-9310) Raise lower Puppet bound to 5.5.10

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -40,7 +40,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.0 < 7.0.0"
+      "version_requirement": ">= 5.5.10 < 7.0.0"
     }
   ],
   "description": "Chocolatey package provider for Puppet",


### PR DESCRIPTION
As Puppet 4 is no longer supported, the supported bound is being raised.
No codes changes are included in this commit.