### PR TITLE
(MODULES-9690) Redact Sensitive Commandline

### DIFF
--- a/lib/puppet/provider/chocolateysource/windows.rb
+++ b/lib/puppet/provider/chocolateysource/windows.rb
@@ -65,7 +65,7 @@ Puppet::Type.type(:chocolateysource).provide(:windows) do
     source[:ensure] = :present
     source[:ensure] = :disabled if disabled
 
-    source[:priority] = 0
+    source[:priority] = '0'
     source[:priority] = element.attributes['priority'].downcase if element.attributes['priority']
 
     source[:bypass_proxy] = false
@@ -132,7 +132,7 @@ Puppet::Type.type(:chocolateysource).provide(:windows) do
         "Detected '#{choco_version}' as your version. Please upgrade Chocolatey to use this resource."
     end
 
-    if choco_version < Gem::Version.new(MINIMUM_SUPPORTED_CHOCO_VERSION_PRIORITY) && resource[:priority] && resource[:priority] != 0
+    if choco_version < Gem::Version.new(MINIMUM_SUPPORTED_CHOCO_VERSION_PRIORITY) && resource[:priority] && resource[:priority] != '0'
       Puppet.warning("Chocolatey is unable to manage priority for sources when version is less than #{MINIMUM_SUPPORTED_CHOCO_VERSION_PRIORITY}. The value you set will be ignored.")
     end
 
@@ -174,6 +174,8 @@ Puppet::Type.type(:chocolateysource).provide(:windows) do
 
   def flush
     args = []
+    opts = {}
+
     args << 'source'
 
     # look at the hash, then flush if present.
@@ -195,6 +197,7 @@ Puppet::Type.type(:chocolateysource).provide(:windows) do
       if resource[:user] && resource[:user] != ''
         args << '--user' << resource[:user]
         args << '--password' << resource[:password]
+        opts = { sensitive: true, failonfail: true, combine: true }
       end
 
       choco_gem_version = Gem::Version.new(PuppetX::Chocolatey::ChocolateyCommon.choco_version)
@@ -216,7 +219,7 @@ Puppet::Type.type(:chocolateysource).provide(:windows) do
     end
 
     begin
-      Puppet::Util::Execution.execute([command(:chocolatey), *args])
+      Puppet::Util::Execution.execute([command(:chocolatey), *args], opts)
     rescue Puppet::ExecutionFailure
       raise Puppet::Error, "An error occurred running choco. Unable to set Chocolatey source configuration for #{inspect}"
     end

--- a/spec/acceptance/sources_spec.rb
+++ b/spec/acceptance/sources_spec.rb
@@ -4,6 +4,14 @@ describe 'chocolateysource resource' do
   context 'create resource' do
     include_context 'backup and reset config'
 
+    let(:pp_remove) do
+      <<-MANIFEST
+        chocolateysource {'chocolatey':
+          ensure             => absent,
+        }
+      MANIFEST
+    end
+
     let(:pp_chocolateysource) do
       <<-MANIFEST
         chocolateysource {'chocolatey':
@@ -20,7 +28,10 @@ describe 'chocolateysource resource' do
     end
 
     it 'applies manifest, sets config' do
-      idempotent_apply(pp_chocolateysource)
+      apply_manifest(pp_remove)
+      apply_manifest(pp_chocolateysource, debug: true) do |result|
+        expect(result.stdout).to match(%r{Debug: Executing: '\[redacted\]'})
+      end
       run_shell(config_content_command, acceptable_exit_codes: [0]) do |result|
         expect(get_xml_value("//sources/source[@id='chocolatey']/@value", result.stdout).to_s).to match(%r{https:\/\/chocolatey.org\/api\/v2})
         expect(get_xml_value("//sources/source[@id='chocolatey']/@priority", result.stdout).to_s).to match(%r{2})

--- a/spec/unit/puppet/provider/chocolateysource/windows_spec.rb
+++ b/spec/unit/puppet/provider/chocolateysource/windows_spec.rb
@@ -495,7 +495,7 @@ describe provider do
     resource_name = 'yup'
     resource_location = 'loc'
     resource_ensure = :present
-    resource_priority = 10
+    resource_priority = '10'
     resource_user = 'thatguy'
     resource_password = 'secrets!'
     resource_bypass_proxy = :true
@@ -519,7 +519,7 @@ describe provider do
                                                                  'source', 'add',
                                                                  '--name', resource_name,
                                                                  '--source', resource_location,
-                                                                 '--priority', 0])
+                                                                 '--priority', '0'], {})
 
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'source', 'enable',
@@ -546,7 +546,7 @@ describe provider do
                                                                  '--bypass-proxy',
                                                                  '--allow-self-service',
                                                                  '--admin-only',
-                                                                 '--priority', resource_priority])
+                                                                 '--priority', resource_priority], combine: true, failonfail: true, sensitive: true)
 
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'source', 'enable',
@@ -562,7 +562,7 @@ describe provider do
                                                                  'source', 'add',
                                                                  '--name', resource_name,
                                                                  '--source', resource_location,
-                                                                 '--priority', resource_priority])
+                                                                 '--priority', resource_priority], {})
 
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'source', 'enable',
@@ -580,7 +580,8 @@ describe provider do
                                                                  '--name', resource_name,
                                                                  '--source', resource_location,
                                                                  '--bypass-proxy',
-                                                                 '--priority', 0])
+                                                                 '--priority', '0'],
+                                                                {})
 
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'source', 'enable',
@@ -598,7 +599,8 @@ describe provider do
                                                                  '--name', resource_name,
                                                                  '--source', resource_location,
                                                                  '--allow-self-service',
-                                                                 '--priority', 0])
+                                                                 '--priority', '0'],
+                                                                {})
 
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'source', 'enable',
@@ -616,7 +618,8 @@ describe provider do
                                                                  '--name', resource_name,
                                                                  '--source', resource_location,
                                                                  '--admin-only',
-                                                                 '--priority', 0])
+                                                                 '--priority', '0'],
+                                                                {})
 
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'source', 'enable',
@@ -636,7 +639,7 @@ describe provider do
                                                                  '--source', resource_location,
                                                                  '--user', resource_user,
                                                                  '--password', resource_password,
-                                                                 '--priority', 0])
+                                                                 '--priority', '0'], combine: true, failonfail: true, sensitive: true)
 
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'source', 'enable',
@@ -655,7 +658,7 @@ describe provider do
                                                                  '--name', resource_name,
                                                                  '--source', resource_location,
                                                                  '--user', resource_user,
-                                                                 '--password', resource_password])
+                                                                 '--password', resource_password], combine: true, failonfail: true, sensitive: true)
 
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'source', 'enable',
@@ -672,7 +675,7 @@ describe provider do
                                                                  'source', 'add',
                                                                  '--name', resource_name,
                                                                  '--source', resource_location,
-                                                                 '--priority', 0])
+                                                                 '--priority', '0'], {})
 
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'source', 'enable',
@@ -690,7 +693,7 @@ describe provider do
                                                                  '--name', resource_name,
                                                                  '--source', resource_location,
                                                                  '--bypass-proxy',
-                                                                 '--priority', 0])
+                                                                 '--priority', '0'], {})
 
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'source', 'enable',
@@ -707,7 +710,7 @@ describe provider do
                                                                  'source', 'add',
                                                                  '--name', resource_name,
                                                                  '--source', resource_location,
-                                                                 '--priority', 0])
+                                                                 '--priority', '0'], {})
 
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'source', 'enable',
@@ -725,7 +728,7 @@ describe provider do
                                                                  '--name', resource_name,
                                                                  '--source', resource_location,
                                                                  '--allow-self-service',
-                                                                 '--priority', 0])
+                                                                 '--priority', '0'], {})
 
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'source', 'enable',
@@ -743,7 +746,7 @@ describe provider do
                                                                  '--name', resource_name,
                                                                  '--source', resource_location,
                                                                  '--admin-only',
-                                                                 '--priority', 0])
+                                                                 '--priority', '0'], {})
 
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'source', 'enable',
@@ -758,7 +761,8 @@ describe provider do
                                                                  'source', 'add',
                                                                  '--name', resource_name,
                                                                  '--source', resource_location,
-                                                                 '--priority', 0])
+                                                                 '--priority', '0'],
+                                                                {})
 
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'source', 'enable',
@@ -773,7 +777,8 @@ describe provider do
                                                                  'source', 'add',
                                                                  '--name', resource_name,
                                                                  '--source', resource_location,
-                                                                 '--priority', 0])
+                                                                 '--priority', '0'],
+                                                                {})
 
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'source', 'enable',
@@ -789,7 +794,8 @@ describe provider do
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'source', 'add',
                                                                  '--name', resource_name,
-                                                                 '--source', resource_location])
+                                                                 '--source', resource_location],
+                                                                {})
 
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'source', 'enable',
@@ -805,7 +811,8 @@ describe provider do
 
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'source', 'disable',
-                                                                 '--name', 'chocolatey'])
+                                                                 '--name', 'chocolatey'],
+                                                                {})
 
       resource.flush
     end
@@ -817,7 +824,8 @@ describe provider do
       expect(PuppetX::Chocolatey::ChocolateyCommon).to receive(:choco_version).never
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'source', 'remove',
-                                                                 '--name', resource_name])
+                                                                 '--name', resource_name],
+                                                                {})
 
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'source', 'enable',
@@ -832,7 +840,7 @@ describe provider do
                                                                  'source', 'add',
                                                                  '--name', resource_name,
                                                                  '--source', resource_location,
-                                                                 '--priority', 0]).and_raise(Puppet::ExecutionFailure, 'Nooooo')
+                                                                 '--priority', '0'], {}).and_raise(Puppet::ExecutionFailure, 'Nooooo')
 
       expect { resource.flush }.to raise_error(Puppet::Error, %r{Unable to set Chocolatey source})
     end


### PR DESCRIPTION
This change redacts the commandline used with the `chocolateysource`
type if the user supplies a password.

If the user does not set a password for the source then no redaction
takes place. If a password is supplied then the entire commandline that
contains the password will be redacted.

This change also allows the user to specify a value to the `password`
parameter using the `Sensitive` data type, but note that this is not
required. The commandline will be redacted even if a normal string is
provided, and using the `Sensitive` type will cause Puppet to raise
a warning, even though nothing is wrong.