### PR TITLE
Update registry version_requirement

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs/registry",
-      "version_requirement": ">= 1.0.0 < 3.0.0"
+      "version_requirement": ">= 1.0.0 < 4.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Looks like puppetlabs-registry has been updated to v 3.0.0. puppetlabs-chocolatey currently depends on registry < 3.0.0

Change log looks pretty safe:
https://github.com/puppetlabs/puppetlabs-registry/compare/2.1.0...v3.0.0