### PR TITLE
(FM-8275) Add vagrant provision list

### DIFF
--- a/provision.yaml
+++ b/provision.yaml
@@ -2,6 +2,9 @@
 default:
   provisioner: vmpooler
   images: ['win-2016-x86_64']
+vagrant:
+  provisioner: vagrant
+  images: ['gusztavvargadr/windows-server']
 release_checks:
   provisioner: vmpooler
   images: ['win-2008-x86_64', 'win-2008r2-x86_64', 'win-2012-x86_64', 'win-2012r2-x86_64', 'win-2016-core-x86_64', 'win-2019-core-x86_64', 'win-7-x86_64', 'win-81-x86_64', 'win-10-pro-x86_64']


### PR DESCRIPTION
Prior to this commit the only provisioners included in
the provision lists were docker and vmpooler, neither
of which are particularly accessible to folks developing
on Windows outside of Puppet.

This commit adds a list which leverages the vagrant
provisioner.