### PR TITLE
Tasks and plans for chocolatey actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,65 @@ might want to do this in a default:
   * When Chocolatey is version `0.10.4` or later and "Verbose" is not specified as `true` Chocolatey will be run with the `--no-progress` parameter, limiting the erroneous output of download information to the logs.
 * "log_output" causes the output of chocolatey upgrades and installs to be
   shown.
+  
+### Bolt Tasks
+
+This module contains several Bolt tasks that allow for ad-hoc actions to be performed.
+
+#### Installing Chocolatey with Bolt
+
+You can install Chocolatey with Bolt by running the `chocolatey::install` task.
+This task takes parameters similar to the `chocolatey` Puppet manifest:
+
+``` bash
+bolt task run chocolatey::install --targets myhosts
+```
+
+#### Use an internal chocolatey.nupkg for Chocolatey installation with Bolt
+
+``` bash
+bolt task run chocolatey::install --targets myhosts download_url=https://internal.tld/chocolatey.nupkg
+```
+
+#### Adding a new source with Bolt
+
+Tasks are also available to manipulate Chocolatey sources. To add a new source:
+
+``` bash
+bolt task run chocolatey::source_add --targets myhsots name=internal location=https://internal.tld/chocolatey
+```
+
+#### Removing a source with Bolt
+
+To remove an existing source:
+
+``` bash
+bolt task run chocolatey::source_remove --targets myhsots name=myexistingsource
+```
+
+#### Disabling a source with Bolt
+
+You can also disable a source in Bolt (the following disables the default community source):
+
+``` bash
+bolt task run chocolatey::source_disable --targets myhsots name=chocolatey
+```
+
+#### Enabling a source with Bolt
+
+To enable a source:
+
+``` bash
+bolt task run chocolatey::source_enable --targets myhsots name=mysource
+```
+
+#### Listing all sources with Bolt
+
+To get a list of all configured sources:
+
+``` bash
+bolt task run chocolatey::source_list --targets myhsots
+```
 
 ## Reference
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -21,6 +21,16 @@ _Private Classes_
 * [`chocolateyfeature`](#chocolateyfeature): Allows managing features for Chocolatey. Features are configuration that act as feature flippers to turn on or off certain aspects of how Cho
 * [`chocolateysource`](#chocolateysource): Allows managing sources for Chocolatey. A source can be a folder, a CIFS share, a NuGet Http OData feed, or a full Package Gallery. Learn mor
 
+**Tasks**
+
+* [`install`](#install): Installs Chocolatey on a set of targets.
+* [`source`](#source): Allows modifying sources for Chocolatey. A source can be a folder, a CIFS share, a NuGet Http OData feed, or a full Package Gallery. Learn mo
+* [`source_add`](#source_add): Allows modifying sources for Chocolatey. A source can be a folder, a CIFS share, a NuGet Http OData feed, or a full Package Gallery. Learn mo
+* [`source_disable`](#source_disable): Disables a Chocolatey source on a set of targets.
+* [`source_enable`](#source_enable): Enables a Chocolatey source on a set of targets.
+* [`source_list`](#source_list): List the Chocolatey sources on a set of targets.
+* [`source_remove`](#source_remove): Removes a Chocolatey source on a set of targets.
+
 ## Classes
 
 ### chocolatey
@@ -361,4 +371,204 @@ same as setting the value to nil or not specifying
 the property at all.
 
 Default value: ''
+
+## Tasks
+
+### install
+
+Installs Chocolatey on a set of targets.
+
+**Supports noop?** false
+
+#### Parameters
+
+##### `download_url`
+
+Data type: `Optional[String[1]]`
+
+A url that will return `chocolatey.nupkg`. This must be a url, but not necessarily an OData feed. Any old url location will work. Defaults to `'https://chocolatey.org/api/v2/package/chocolatey/'`.
+
+##### `use_7zip`
+
+Data type: `Optional[Boolean]`
+
+Whether to use built-in shell or allow installer to download 7zip to extract `chocolatey.nupkg` during installation. Defaults to `false`
+
+##### `install_proxy`
+
+Data type: `Optional[String[1]]`
+
+Proxy server to use to use for installation of chocolatey itself or `undef` to not use a proxy
+
+##### `seven_zip_exe`
+
+Data type: `Optional[String[1]]`
+
+Path on the windows host where the 7zip binary (7za.exe) is installed. Defaults to `'C:/Windows/Temp/7za.exe'`.
+
+### source
+
+Allows modifying sources for Chocolatey. A source can be a folder, a CIFS share, a NuGet Http OData feed, or a full Package Gallery. Learn more about sources at https://chocolatey.org/docs/how-to-host-feed
+
+**Supports noop?** false
+
+#### Parameters
+
+##### `command`
+
+Data type: `Enum['add', 'remove', 'enable', 'disable', 'list']`
+
+What action should be taken on the source. 'add' will add a new source to Chocolatey. 'remove' will remove an existing source from Chocolatey. 'disable' will disable an existing source in Chocolatey. 'list' will list all current Chocolatey sources.
+
+##### `name`
+
+Data type: `Optional[String[1]]`
+
+The name of the source. Used for uniqueness. Optional if "command = 'list'".
+
+##### `location`
+
+Data type: `Optional[String[1]]`
+
+The location of the source repository. Can be a url pointing to an OData feed (like chocolatey/chocolatey_server), a CIFS (UNC) share, or a local folder. Required when "command = 'add'".
+
+##### `user`
+
+Data type: `Optional[String[1]]`
+
+Optional user name for authenticated feeds. Requires at least Chocolatey v0.9.9.0. Defaults to 'undef'. Specifying an empty value is the same as setting the value to 'undef' or not specifying the property at all.
+
+##### `password`
+
+Data type: `Optional[String[1]]`
+
+Optional user password for authenticated feeds.
+
+##### `priority`
+
+Data type: `Optional[Integer]`
+
+Optional priority for explicit feed order when searching for packages across multiple feeds. The lower the number the higher the priority. Sources with a 0 priority are considered no priority and are added after other sources with a priority number. Requires at least Chocolatey v0.9.9.9. Defaults to 0.
+
+##### `bypass_proxy`
+
+Data type: `Optional[Boolean]`
+
+Option to specify whether this source should explicitly bypass any explicitly or system configured proxies. Requires at least Chocolatey v0.10.4. Defaults to false.
+
+##### `admin_only`
+
+Data type: `Optional[Boolean]`
+
+Option to specify whether this source should visible to Windows user accounts in the Administrators group only. Requires Chocolatey for Business (C4B) v1.12.2+ and at least Chocolatey v0.10.8 for the setting to be respected. Defaults to false.
+
+##### `allow_self_service`
+
+Data type: `Optional[Boolean]`
+
+Option to specify whether this source should be allowed to be used with Chocolatey Self Service. Requires Chocolatey for Business (C4B) v1.10.0+ with the feature useBackgroundServiceWithSelfServiceSourcesOnly turned on in order to be respected. Also requires at least Chocolatey v0.10.4 for the setting to be enabled. Defaults to false.
+
+### source_add
+
+Allows modifying sources for Chocolatey. A source can be a folder, a CIFS share, a NuGet Http OData feed, or a full Package Gallery. Learn more about sources at https://chocolatey.org/docs/how-to-host-feed
+
+**Supports noop?** false
+
+#### Parameters
+
+##### `name`
+
+Data type: `String[1]`
+
+The name of the source. Used for uniqueness
+
+##### `location`
+
+Data type: `String[1]`
+
+The location of the source repository. Can be a url pointing to an OData feed (like chocolatey/chocolatey_server), a CIFS (UNC) share, or a local folder.
+
+##### `user`
+
+Data type: `Optional[String[1]]`
+
+Optional user name for authenticated feeds. Requires at least Chocolatey v0.9.9.0. Defaults to 'undef'. Specifying an empty value is the same as setting the value to 'undef' or not specifying the property at all.
+
+##### `password`
+
+Data type: `Optional[String[1]]`
+
+Optional user password for authenticated feeds.
+
+##### `priority`
+
+Data type: `Optional[Integer]`
+
+Optional priority for explicit feed order when searching for packages across multiple feeds. The lower the number the higher the priority. Sources with a 0 priority are considered no priority and are added after other sources with a priority number. Requires at least Chocolatey v0.9.9.9. Defaults to 0.
+
+##### `bypass_proxy`
+
+Data type: `Optional[Boolean]`
+
+Option to specify whether this source should explicitly bypass any explicitly or system configured proxies. Requires at least Chocolatey v0.10.4. Defaults to false.
+
+##### `admin_only`
+
+Data type: `Optional[Boolean]`
+
+Option to specify whether this source should visible to Windows user accounts in the Administrators group only. Requires Chocolatey for Business (C4B) v1.12.2+ and at least Chocolatey v0.10.8 for the setting to be respected. Defaults to false.
+
+##### `allow_self_service`
+
+Data type: `Optional[Boolean]`
+
+Option to specify whether this source should be allowed to be used with Chocolatey Self Service. Requires Chocolatey for Business (C4B) v1.10.0+ with the feature useBackgroundServiceWithSelfServiceSourcesOnly turned on in order to be respected. Also requires at least Chocolatey v0.10.4 for the setting to be enabled. Defaults to false.
+
+### source_disable
+
+Disables a Chocolatey source on a set of targets.
+
+**Supports noop?** false
+
+#### Parameters
+
+##### `name`
+
+Data type: `String[1]`
+
+The name of the source. Used for uniqueness
+
+### source_enable
+
+Enables a Chocolatey source on a set of targets.
+
+**Supports noop?** false
+
+#### Parameters
+
+##### `name`
+
+Data type: `String[1]`
+
+The name of the source. Used for uniqueness
+
+### source_list
+
+List the Chocolatey sources on a set of targets.
+
+**Supports noop?** false
+
+### source_remove
+
+Removes a Chocolatey source on a set of targets.
+
+**Supports noop?** false
+
+#### Parameters
+
+##### `name`
+
+Data type: `String[1]`
+
+The name of the source. Used for uniqueness
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,7 +34,7 @@
 #     enable_autouninstaller => false,
 #   }
 #
-# @param [String] choco_install_location Where Chocolatey install should be
+# @param [Stdlib::Windowspath] choco_install_location Where Chocolatey install should be
 #   located. This needs to be an absolute path starting with a drive letter
 #   e.g. `c:\`. Defaults to the currently detected install location based on
 #   the `ChocolateyInstall` environment variable, falls back to
@@ -53,7 +53,7 @@
 #   be allowed for the install of Chocolatey (including .NET Framework 4 if
 #   necessary). Defaults to `1500` (25 minutes).
 #
-# @param [String] chocolatey_download_url A url that will return
+# @param [Stdlib::Filesource] chocolatey_download_url A url that will return
 #   `chocolatey.nupkg`. This must be a url, but not necessarily an OData feed.
 #   Any old url location will work. Defaults to
 #   `'https://chocolatey.org/api/v2/package/chocolatey/'`.

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,11 +4,7 @@
 class chocolatey::install {
   assert_private()
 
-  $install_proxy = $::chocolatey::install_proxy
-  $_install_proxy = $install_proxy ? {
-    undef   => '$false',
-    default => "'${install_proxy}'",
-  }
+  $install_proxy           = $::chocolatey::install_proxy
   $_download_url           = $::chocolatey::chocolatey_download_url
   $seven_zip_download_url  = $::chocolatey::seven_zip_download_url
   $seven_zip_exe           = "${facts['choco_temp_dir']}\\7za.exe"
@@ -43,12 +39,18 @@ class chocolatey::install {
   }
 
   exec { 'install_chocolatey_official':
-    command     => template('chocolatey/InstallChocolatey.ps1.erb'),
+    command     => file('chocolatey/InstallChocolatey.ps1'),
     creates     => "${::chocolatey::choco_install_location}\\bin\\choco.exe",
     provider    => powershell,
     timeout     => $::chocolatey::choco_install_timeout_seconds,
     logoutput   => $::chocolatey::log_output,
-    environment => ["ChocolateyInstall=${::chocolatey::choco_install_location}"],
+    environment => [
+      "ChocolateyInstall=${::chocolatey::choco_install_location}",
+      "ChocolateyDownloadUrl=${download_url}",
+      "ChocolateyUnzipType=${unzip_type}",
+      "ChocolateyInstallProxy=${install_proxy}",
+      "Chocolatey7ZipExe=${seven_zip_exe}",
+    ],
     require     => Registry_value['ChocolateyInstall environment value'],
   }
 }

--- a/tasks/install.json
+++ b/tasks/install.json
@@ -1,0 +1,29 @@
+{
+  "description": "Installs Chocolatey on a set of targets.",
+  "implementations": [
+    {
+      "name": "install.ps1",
+      "requirements": ["powershell"],
+      "files": ["chocolatey/files/InstallChocolatey.ps1"]
+    }
+  ],
+  "parameters": {
+    "download_url": {
+      "description": "A url that will return `chocolatey.nupkg`. This must be a url, but not necessarily an OData feed. Any old url location will work. Defaults to `'https://chocolatey.org/api/v2/package/chocolatey/'`.",
+      "type": "Optional[String[1]]"
+    },
+    "use_7zip": {
+      "description": "Whether to use built-in shell or allow installer to download 7zip to extract `chocolatey.nupkg` during installation. Defaults to `false`",
+      "type": "Optional[Boolean]"
+    },
+    "install_proxy": {
+      "description": "Proxy server to use to use for installation of chocolatey itself or `undef` to not use a proxy",
+      "type": "Optional[String[1]]"
+    },
+    "seven_zip_exe": {
+      "description": "Path on the windows host where the 7zip binary (7za.exe) is installed. Defaults to `'C:/Windows/Temp/7za.exe'`.",
+      "type": "Optional[String[1]]"
+    }
+  }
+}
+

--- a/tasks/install.ps1
+++ b/tasks/install.ps1
@@ -1,0 +1,20 @@
+[CmdletBinding()]
+Param(
+  [string]$download_url = 'https://chocolatey.org/api/v2/package/chocolatey/',
+  [boolean]$use_7zip = $False,
+  [string]$install_proxy = '',
+  [string]$seven_zip_exe = "C:\Windows\Temp\7za.exe",
+  [String]$_installdir
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+
+if ($use_7zip) {
+  $unzip_type = '7zip'
+} else {
+  $unzip_type = 'windows'
+}
+
+& "$_installdir\chocolatey\files\InstallChocolatey.ps1" -DownloadUrl $download_url -UnzipType $unzip_type -InstallProxy $install_proxy -SevenZipExe "$seven_zip_exe"

--- a/tasks/source.json
+++ b/tasks/source.json
@@ -1,0 +1,49 @@
+{
+  "description": "Allows modifying sources for Chocolatey. A source can be a folder, a CIFS share, a NuGet Http OData feed, or a full Package Gallery. Learn more about sources at https://chocolatey.org/docs/how-to-host-feed",
+  "implementations": [
+    {
+      "name": "source.ps1",
+      "requirements": ["powershell"]
+    }
+  ],
+  "parameters": {
+    "command": {
+      "description": "What action should be taken on the source. 'add' will add a new source to Chocolatey. 'remove' will remove an existing source from Chocolatey. 'disable' will disable an existing source in Chocolatey. 'list' will list all current Chocolatey sources.",
+      "type": "Enum['add', 'remove', 'enable', 'disable', 'list']"
+    },
+    "name": {
+      "description": "The name of the source. Used for uniqueness. Optional if \"command = 'list'\".",
+      "type": "Optional[String[1]]"
+    },
+    "location": {
+      "description": "The location of the source repository. Can be a url pointing to an OData feed (like chocolatey/chocolatey_server), a CIFS (UNC) share, or a local folder. Required when \"command = 'add'\".",
+      "type": "Optional[String[1]]"
+    },
+    "user": {
+      "description": "Optional user name for authenticated feeds. Requires at least Chocolatey v0.9.9.0. Defaults to 'undef'. Specifying an empty value is the same as setting the value to 'undef' or not specifying the property at all.",
+      "type": "Optional[String[1]]"
+    },
+    "password": {
+      "description": "Optional user password for authenticated feeds.",
+      "type": "Optional[String[1]]",
+      "sensitive": true
+    },
+    "priority": {
+      "description": "Optional priority for explicit feed order when searching for packages across multiple feeds. The lower the number the higher the priority. Sources with a 0 priority are considered no priority and are added after other sources with a priority number. Requires at least Chocolatey v0.9.9.9. Defaults to 0.",
+      "type": "Optional[Integer]"
+    },
+    "bypass_proxy": {
+      "description": "Option to specify whether this source should explicitly bypass any explicitly or system configured proxies. Requires at least Chocolatey v0.10.4. Defaults to false.",
+      "type": "Optional[Boolean]"
+    },
+    "admin_only": {
+      "description": "Option to specify whether this source should visible to Windows user accounts in the Administrators group only. Requires Chocolatey for Business (C4B) v1.12.2+ and at least Chocolatey v0.10.8 for the setting to be respected. Defaults to false.",
+      "type": "Optional[Boolean]"
+    },
+    "allow_self_service": {
+      "description": "Option to specify whether this source should be allowed to be used with Chocolatey Self Service. Requires Chocolatey for Business (C4B) v1.10.0+ with the feature useBackgroundServiceWithSelfServiceSourcesOnly turned on in order to be respected. Also requires at least Chocolatey v0.10.4 for the setting to be enabled. Defaults to false.",
+      "type": "Optional[Boolean]"
+    }
+  }
+}
+

--- a/tasks/source.ps1
+++ b/tasks/source.ps1
@@ -1,0 +1,54 @@
+[CmdletBinding()]
+Param(
+  [string]$command = '',
+  [string]$name = '',
+  [string]$location = '',
+  [string]$user = '',
+  [string]$password = '',
+  [int]$priority = 0,
+  [boolean]$bypass_proxy = $false,
+  [boolean]$allow_self_service = $false,
+  [boolean]$admin_only = $false,
+  [string]$_task
+)
+
+if ($command -eq '') {
+  # $_task will be something like 'chocolatey::source_xxx'
+  # we want to extract the 'xxx' from the end as that's our command
+  $task_parts = $_task -split "chocolatey\:\:source_"
+  # parts[0] = ''
+  # parts[1] = 'xxx'
+  $command = $task_parts[1]
+}
+
+$cmd = @('choco', 'source', $command, '--limit-output', '--no-progress')
+
+if ($command -ne 'list') {
+  $cmd += @('--name', $name)
+}
+
+if ($command -eq 'add') {
+  $cmd += @('--source', $location)
+
+  if ($user -ne '') {
+    $cmd += @('--user', $user)
+    $cmd += @('--password', $password)
+  }
+
+  if ($bypass_proxy) {
+    $cmd += @('--bypass-proxy')
+  }
+
+  if ($allow_self_service) {
+    $cmd += @('--allow-self-service')
+  }
+
+  if ($admin_only) {
+    $cmd += @('--admin-only')
+  }
+
+  $cmd += @('--priority', "$priority")
+}
+
+$cmd_str = $cmd -join ' '
+iex "& $cmd_str"

--- a/tasks/source_add.json
+++ b/tasks/source_add.json
@@ -1,0 +1,45 @@
+{
+  "description": "Allows modifying sources for Chocolatey. A source can be a folder, a CIFS share, a NuGet Http OData feed, or a full Package Gallery. Learn more about sources at https://chocolatey.org/docs/how-to-host-feed",
+  "implementations": [
+    {
+      "name": "source.ps1",
+      "requirements": ["powershell"]
+    }
+  ],
+  "parameters": {
+    "name": {
+      "description": "The name of the source. Used for uniqueness",
+      "type": "String[1]"
+    },
+    "location": {
+      "description": "The location of the source repository. Can be a url pointing to an OData feed (like chocolatey/chocolatey_server), a CIFS (UNC) share, or a local folder.",
+      "type": "String[1]"
+    },
+    "user": {
+      "description": "Optional user name for authenticated feeds. Requires at least Chocolatey v0.9.9.0. Defaults to 'undef'. Specifying an empty value is the same as setting the value to 'undef' or not specifying the property at all.",
+      "type": "Optional[String[1]]"
+    },
+    "password": {
+      "description": "Optional user password for authenticated feeds.",
+      "type": "Optional[String[1]]",
+      "sensitive": true
+    },
+    "priority": {
+      "description": "Optional priority for explicit feed order when searching for packages across multiple feeds. The lower the number the higher the priority. Sources with a 0 priority are considered no priority and are added after other sources with a priority number. Requires at least Chocolatey v0.9.9.9. Defaults to 0.",
+      "type": "Optional[Integer]"
+    },
+    "bypass_proxy": {
+      "description": "Option to specify whether this source should explicitly bypass any explicitly or system configured proxies. Requires at least Chocolatey v0.10.4. Defaults to false.",
+      "type": "Optional[Boolean]"
+    },
+    "admin_only": {
+      "description": "Option to specify whether this source should visible to Windows user accounts in the Administrators group only. Requires Chocolatey for Business (C4B) v1.12.2+ and at least Chocolatey v0.10.8 for the setting to be respected. Defaults to false.",
+      "type": "Optional[Boolean]"
+    },
+    "allow_self_service": {
+      "description": "Option to specify whether this source should be allowed to be used with Chocolatey Self Service. Requires Chocolatey for Business (C4B) v1.10.0+ with the feature useBackgroundServiceWithSelfServiceSourcesOnly turned on in order to be respected. Also requires at least Chocolatey v0.10.4 for the setting to be enabled. Defaults to false.",
+      "type": "Optional[Boolean]"
+    }
+  }
+}
+

--- a/tasks/source_disable.json
+++ b/tasks/source_disable.json
@@ -1,0 +1,16 @@
+{
+  "description": "Disables a Chocolatey source on a set of targets.",
+  "implementations": [
+    {
+      "name": "source.ps1",
+      "requirements": ["powershell"]
+    }
+  ],
+  "parameters": {
+    "name": {
+      "description": "The name of the source. Used for uniqueness",
+      "type": "String[1]"
+    }
+  }
+}
+

--- a/tasks/source_enable.json
+++ b/tasks/source_enable.json
@@ -1,0 +1,16 @@
+{
+  "description": "Enables a Chocolatey source on a set of targets.",
+  "implementations": [
+    {
+      "name": "source.ps1",
+      "requirements": ["powershell"]
+    }
+  ],
+  "parameters": {
+    "name": {
+      "description": "The name of the source. Used for uniqueness",
+      "type": "String[1]"
+    }
+  }
+}
+

--- a/tasks/source_list.json
+++ b/tasks/source_list.json
@@ -1,0 +1,11 @@
+{
+  "description": "List the Chocolatey sources on a set of targets.",
+  "implementations": [
+    {
+      "name": "source.ps1",
+      "requirements": ["powershell"]
+    }
+  ],
+  "parameters": {}
+}
+

--- a/tasks/source_remove.json
+++ b/tasks/source_remove.json
@@ -1,0 +1,16 @@
+{
+  "description": "Removes a Chocolatey source on a set of targets.",
+  "implementations": [
+    {
+      "name": "source.ps1",
+      "requirements": ["powershell"]
+    }
+  ],
+  "parameters": {
+    "name": {
+      "description": "The name of the source. Used for uniqueness",
+      "type": "String[1]"
+    }
+  }
+}
+


### PR DESCRIPTION
As a user when i'm setting up a system from scratch, i would like to use Chocolatey to install packages (for example Puppet). Today we have to run a hard-coded Chocolatey script in our code. I would like this to be usable by our organization in a more generic way and also share the capability with others.

**Changes:**
- Created a task to install Chocolatey called `chocolatey::install`
  - This task reuses the `InstallChocolatey.ps1` script (details on changes below)
- Converted `templates/InstallChocolatey.ps1.erb` template into a file that accepts parameters (bolt) or environment variables (puppet).
  - I wanted to reuse the existing `InstallChocolatey.ps1` for both Bolt and Puppet so we don't have to maintain two copies of the file.
  - Because Bolt tasks can't render templates in a task, we needed to convert the template to a script.
  - The way that worked in the cleanest manner was to accept Environment variables from the Puppet `exec` resource. From the Bolt side, we're able to pass PowerShell style arguments.
- Updated `chocolatey::install` Puppet manifest to execute the file instead of the template. This `exec` resource now passes Environment variables instead of rendering them directly in the script.
- Created a task `chocolatey::source` to manipulate Chocolatey source(s)
- Created facade tasks for things like `chocolatey::source_list` and `chocolatey::source_add`.
- Updated README and REFERENCE with info on new tasks