### PR TITLE
(maint) Move code for chocolatey version in setcode block

### DIFF
--- a/lib/facter/chocolateyversion.rb
+++ b/lib/facter/chocolateyversion.rb
@@ -3,8 +3,8 @@ require Pathname.new(__FILE__).dirname + '../' + 'puppet_x/chocolatey/chocolatey
 
 Facter.add('chocolateyversion') do
   confine osfamily: :windows
-  choco_ver = PuppetX::Chocolatey::ChocolateyVersion.version || '0'
   setcode do
+    choco_ver = PuppetX::Chocolatey::ChocolateyVersion.version || '0'
     choco_ver.to_s
   end
 end


### PR DESCRIPTION
This commit updates chocolatey custom fact because the evaluation
of custom facts code has changed between Facter 2 and Facter 4.
In Facter 2, when a custom fact is loaded, the code in add block
was not executed.
In Facter 4, when a custom fact is loaded, the code outside setcode
block is executed (same as Facter 3).