### PR TITLE
Improve chocolatey::params doc and visibility; mark params.pp as private

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,8 +1,9 @@
 # @summary Sets up default parameters
 #
 # @api private
-
 class chocolatey::params {
+  assert_private()
+
   $install_location         = empty($facts['choco_install_path']) ? {
     false   => $facts['choco_install_path'],
     default => 'C:\ProgramData\chocolatey',


### PR DESCRIPTION
An extra blank line cause the class to be classified as public while the
comments indicate it is private and makes it description vanish.  Also,
the class is not actualy marked as private.

Fix the documentation markup and add proper assertion.
