### PR TITLE
(MODULES-11255) Add basic tasks to manage packages

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,6 +3,7 @@ fixtures:
     stdlib:       'puppetlabs/stdlib'
     powershell:   'puppetlabs/powershell'
     registry:     'puppetlabs/registry'
+    ruby_task_helper: 'puppetlabs/ruby_task_helper'
   repositories:
       facts: 'https://github.com/puppetlabs/puppetlabs-facts.git'
       puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -120,6 +120,10 @@ jobs:
           buildevents cmd $TRACE_ID $STEP_ID 'bundle env' -- bundle env
           echo ::endgroup::
 
+      - name: Create task helper symlink
+        run: |
+          ln -s "${PWD}/spec/fixtures/modules/ruby_task_helper" ..
+
       - name: Run Static & Syntax Tests
         run: |
           buildevents cmd $TRACE_ID $STEP_ID 'static_syntax_checks Puppet ${{ matrix.puppet_version }}, Ruby ${{ matrix.ruby_version }}' -- bundle exec rake syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop

--- a/.sync.yml
+++ b/.sync.yml
@@ -36,6 +36,7 @@ spec/spec_helper.rb:
 .github/workflows/spec.yml:
   checks: 'syntax lint metadata_lint check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop'
   unmanaged: false
+  use_ruby_task_helper: true
 .github/workflows/release.yml:
   unmanaged: false
 .travis.yml:

--- a/metadata.json
+++ b/metadata.json
@@ -19,6 +19,10 @@
     {
       "name": "puppetlabs/registry",
       "version_requirement": ">= 1.0.0 < 5.0.0"
+    },
+    {
+      "name": "puppetlabs/ruby_task_helper",
+      "version_requirement": ">= 0.4.0 < 1.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/tasks/chocolatey_outdated_task_spec.rb
+++ b/spec/tasks/chocolatey_outdated_task_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative '../../tasks/outdated.rb'
+
+describe ChocolateyOutdatedTask do
+  subject { described_class.new.task }
+
+  before(:each) do
+    sucess_status = double
+    allow(sucess_status).to receive(:==).with(0).and_return(true)
+    allow(sucess_status).to receive(:exited?).and_return(true)
+    allow(sucess_status).to receive(:exitstatus).and_return(0)
+    allow(Open3).to receive(:capture2).with('choco', 'outdated', '--no-color', '--limit-output').and_return([<<~OUTPUT, sucess_status])
+    puppet-bolt|3.20.0|3.21.0|false
+    OUTPUT
+  end
+
+  it { is_expected.to eq({ status: [{ package: 'puppet-bolt', version: '3.20.0', available_version: '3.21.0', pinned: false }] }) }
+end

--- a/spec/tasks/chocolatey_pin_task_spec.rb
+++ b/spec/tasks/chocolatey_pin_task_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative '../../tasks/pin.rb'
+
+describe ChocolateyPinTask do
+  subject { described_class.new.task(action: action, package: package, version: version) }
+
+  let(:package) { nil }
+  let(:version) { nil }
+
+  let(:sucess_status) do
+    res = double
+    allow(res).to receive(:==).with(0).and_return(true)
+    allow(res).to receive(:exited?).and_return(true)
+    allow(res).to receive(:exitstatus).and_return(0)
+    res
+  end
+
+  context 'when action=list' do
+    let(:action) { 'list' }
+
+    before(:each) do
+      allow(Open3).to receive(:capture2).with('choco', 'pin', 'list', '--no-color', '--limit-output').and_return([<<~OUTPUT, sucess_status])
+      puppet-bolt|3.20.0
+      OUTPUT
+    end
+
+    it { is_expected.to eq({ status: [{ package: 'puppet-bolt', version: '3.20.0' }] }) }
+  end
+
+  context 'when action=add' do
+    let(:action) { 'add' }
+    let(:package) { 'puppet-bolt' }
+
+    context 'without version' do
+      before(:each) { allow(Open3).to receive(:capture2).with('choco', 'pin', 'add', '--no-color', '--limit-output', '--name', 'puppet-bolt').and_return(['', sucess_status]) }
+
+      it { is_expected.to eq(nil) }
+    end
+
+    context 'with version' do
+      let(:version) { '3.21.0' }
+
+      before(:each) { allow(Open3).to receive(:capture2).with('choco', 'pin', 'add', '--no-color', '--limit-output', '--name', 'puppet-bolt', '--version', '3.21.0').and_return(['', sucess_status]) }
+
+      it { is_expected.to eq(nil) }
+    end
+  end
+
+  context 'when action=remove' do
+    let(:action) { 'remove' }
+    let(:package) { 'puppet-bolt' }
+
+    context 'without version' do
+      before(:each) { allow(Open3).to receive(:capture2).with('choco', 'pin', 'remove', '--no-color', '--limit-output', '--name', 'puppet-bolt').and_return(['', sucess_status]) }
+
+      it { is_expected.to eq(nil) }
+    end
+
+    context 'with version' do
+      let(:version) { '3.21.0' }
+
+      before(:each) do
+        allow(Open3).to receive(:capture2).with('choco', 'pin', 'remove', '--no-color', '--limit-output', '--name', 'puppet-bolt', '--version', '3.21.0').and_return(['', sucess_status])
+      end
+
+      it { is_expected.to eq(nil) }
+    end
+  end
+end

--- a/spec/tasks/chocolatey_status_task_spec.rb
+++ b/spec/tasks/chocolatey_status_task_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative '../../tasks/status.rb'
+
+describe ChocolateyStatusTask do
+  subject { described_class.new.task }
+
+  before(:each) do
+    sucess_status = double
+    allow(sucess_status).to receive(:==).with(0).and_return(true)
+    allow(sucess_status).to receive(:exited?).and_return(true)
+    allow(sucess_status).to receive(:exitstatus).and_return(0)
+    allow(Open3).to receive(:capture2).with('choco', 'list', '--local-only', '--no-color', '--limit-output').and_return([<<~OUTPUT, sucess_status])
+    chocolatey|0.11.3
+    puppet-bolt|3.20.0
+    OUTPUT
+  end
+
+  it { is_expected.to eq({ status: [{ package: 'chocolatey', version: '0.11.3' }, { package: 'puppet-bolt', version: '3.20.0' }] }) }
+end

--- a/spec/tasks/chocolatey_task_spec.rb
+++ b/spec/tasks/chocolatey_task_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require_relative '../../tasks/init.rb'
+
+describe ChocolateyTask do
+  subject { described_class.new.task(action: action, package: package, version: version) }
+
+  let(:package) { 'puppet-bolt' }
+  let(:version) { nil }
+
+  let(:sucess_status) do
+    res = double
+    allow(res).to receive(:==).with(0).and_return(true)
+    allow(res).to receive(:exited?).and_return(true)
+    allow(res).to receive(:exitstatus).and_return(0)
+    res
+  end
+
+  context 'when action=install' do
+    let(:action) { 'install' }
+
+    context 'without version' do
+      before(:each) do
+        allow(Open3).to receive(:capture2).with('choco', 'install', 'puppet-bolt', '--yes', '--no-color', '--no-progress').and_return(['', sucess_status])
+      end
+
+      it { is_expected.to eq(nil) }
+    end
+
+    context 'with version' do
+      let(:version) { '3.21.0' }
+
+      before(:each) do
+        allow(Open3).to receive(:capture2).with('choco', 'install', 'puppet-bolt', '--yes', '--no-color', '--no-progress', '--version', '3.21.0').and_return(['', sucess_status])
+      end
+
+      it { is_expected.to eq(nil) }
+    end
+  end
+
+  context 'when action=upgrade' do
+    let(:action) { 'upgrade' }
+
+    context 'without version' do
+      before(:each) do
+        allow(Open3).to receive(:capture2).with('choco', 'upgrade', 'puppet-bolt', '--yes', '--no-color', '--no-progress').and_return(['', sucess_status])
+      end
+
+      it { is_expected.to eq(nil) }
+    end
+
+    context 'with version' do
+      let(:version) { '3.21.0' }
+
+      before(:each) do
+        allow(Open3).to receive(:capture2).with('choco', 'upgrade', 'puppet-bolt', '--yes', '--no-color', '--no-progress', '--version', '3.21.0').and_return(['', sucess_status])
+      end
+
+      it { is_expected.to eq(nil) }
+    end
+  end
+
+  context 'when action=uninstall' do
+    let(:action) { 'uninstall' }
+
+    context 'without version' do
+      before(:each) do
+        allow(Open3).to receive(:capture2).with('choco', 'uninstall', 'puppet-bolt', '--yes', '--no-color', '--no-progress').and_return(['', sucess_status])
+      end
+
+      it { is_expected.to eq(nil) }
+    end
+
+    context 'with version' do
+      let(:version) { '3.21.0' }
+
+      before(:each) do
+        allow(Open3).to receive(:capture2).with('choco', 'uninstall', 'puppet-bolt', '--yes', '--no-color', '--no-progress', '--version', '3.21.0').and_return(['', sucess_status])
+      end
+
+      it { is_expected.to eq(nil) }
+    end
+  end
+end

--- a/tasks/init.json
+++ b/tasks/init.json
@@ -1,0 +1,21 @@
+{
+  "description": "Manage a package",
+  "files": [
+    "ruby_task_helper/files/task_helper.rb"
+  ],
+  "input_method": "stdin",
+  "parameters": {
+    "action": {
+      "description": "Action to perform",
+      "type": "Enum[install,upgrade,uninstall]"
+    },
+    "package": {
+      "description": "Package to manipulate",
+      "type": "String[1]"
+    },
+    "version": {
+      "description": "Use a specific version",
+      "type": "Optional[String[1]]"
+    }
+  }
+}

--- a/tasks/init.rb
+++ b/tasks/init.rb
@@ -1,0 +1,39 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+# frozen_string_literal: true
+
+require 'open3'
+require 'puppet'
+
+require_relative '../../ruby_task_helper/files/task_helper.rb'
+
+# Manage installing, upgrading and uninstalling packages
+class ChocolateyTask < TaskHelper
+  def task(action: nil, package: nil, version: nil)
+    command = [
+      'choco',
+      action,
+      package,
+      '--yes',
+      '--no-color',
+      '--no-progress',
+    ]
+
+    if version
+      command += [
+        '--version',
+        version,
+      ]
+    end
+
+    output, status = Open3.capture2(*command)
+
+    raise TaskHelper::Error.new('choco did not exited normally', "chocolatey/#{action}-error", output) unless status.exited?
+    raise TaskHelper::Error.new("choco exited with error code #{status.exitstatus}", "chocolatey/#{action}-error", output) if status != 0
+
+    nil
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  ChocolateyTask.run
+end

--- a/tasks/outdated.json
+++ b/tasks/outdated.json
@@ -1,0 +1,7 @@
+{
+  "description": "List outdated packages",
+  "files": [
+    "ruby_task_helper/files/task_helper.rb"
+  ],
+  "input_method": "stdin"
+}

--- a/tasks/outdated.rb
+++ b/tasks/outdated.rb
@@ -1,0 +1,37 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+# frozen_string_literal: true
+
+require 'open3'
+require 'puppet'
+
+require_relative '../../ruby_task_helper/files/task_helper.rb'
+
+# Retun a list of packages with pending updates
+class ChocolateyOutdatedTask < TaskHelper
+  def task(**_kwargs)
+    output, status = Open3.capture2('choco', 'outdated', '--no-color', '--limit-output')
+
+    raise TaskHelper::Error.new('choco did not exited normally', 'chocolatey/outdated-error', output) unless status.exited?
+    raise TaskHelper::Error.new("choco exited with error code #{status.exitstatus}", 'chocolatey/outdated-error', output) unless [0, 2].include?(status.exitstatus)
+
+    result = []
+    output.split("\n").each do |line|
+      parts = line.split('|')
+
+      next unless parts.count == 4
+
+      result << {
+        package: parts[0],
+        version: parts[1],
+        available_version: parts[2],
+        pinned: parts[3] == 'true'
+      }
+    end
+
+    { status: result }
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  ChocolateyOutdatedTask.run
+end

--- a/tasks/pin.json
+++ b/tasks/pin.json
@@ -1,0 +1,21 @@
+{
+  "description": "Manage package pinning",
+  "files": [
+    "ruby_task_helper/files/task_helper.rb"
+  ],
+  "input_method": "stdin",
+  "parameters": {
+    "action": {
+      "description": "Action to perform",
+      "type": "Enum[list,add,remove]"
+    },
+    "package": {
+      "description": "Package to manipulate",
+      "type": "Optional[String[1]]"
+    },
+    "version": {
+      "description": "Use a specific version",
+      "type": "Optional[String[1]]"
+    }
+  }
+}

--- a/tasks/pin.rb
+++ b/tasks/pin.rb
@@ -1,0 +1,62 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+# frozen_string_literal: true
+
+require 'open3'
+require 'puppet'
+
+require_relative '../../ruby_task_helper/files/task_helper.rb'
+
+# Manage installing, upgrading and uninstalling packages
+class ChocolateyPinTask < TaskHelper
+  def task(action: nil, package: nil, version: nil)
+    command = [
+      'choco',
+      'pin',
+      action,
+      '--no-color',
+      '--limit-output',
+    ]
+
+    if package
+      command += [
+        '--name',
+        package,
+      ]
+    end
+
+    if version
+      command += [
+        '--version',
+        version,
+      ]
+    end
+
+    output, status = Open3.capture2(*command)
+
+    raise TaskHelper::Error.new('choco did not exited normally', "chocolatey/pin-#{action}-error", output) unless status.exited?
+    raise TaskHelper::Error.new("choco exited with error code #{status.exitstatus}", "chocolatey/pin-#{action}-error", output) if status != 0
+
+    if action == 'list'
+      result = []
+
+      output.split("\n").each do |line|
+        parts = line.split('|')
+
+        next unless parts.count == 2
+
+        result << {
+          package: parts[0],
+          version: parts[1],
+        }
+      end
+
+      return { status: result }
+    end
+
+    nil
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  ChocolateyPinTask.run
+end

--- a/tasks/status.json
+++ b/tasks/status.json
@@ -1,0 +1,7 @@
+{
+  "description": "List currently installed packages",
+  "files": [
+    "ruby_task_helper/files/task_helper.rb"
+  ],
+  "input_method": "stdin"
+}

--- a/tasks/status.rb
+++ b/tasks/status.rb
@@ -1,0 +1,36 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+# frozen_string_literal: true
+
+require_relative '../../ruby_task_helper/files/task_helper.rb'
+
+require 'open3'
+require 'puppet'
+
+# Return a list of installed packages
+class ChocolateyStatusTask < TaskHelper
+  def task(**_kwargs)
+    output, status = Open3.capture2('choco', 'list', '--local-only', '--no-color', '--limit-output')
+
+    raise TaskHelper::Error.new('choco did not exited normally', 'chocolatey/status-error', output) unless status.exited?
+    raise TaskHelper::Error.new("choco exited with error code #{status.exitstatus}", 'chocolatey/status-error', output) if status != 0
+
+    result = []
+
+    output.split("\n").each do |line|
+      parts = line.split('|')
+
+      next unless parts.count == 2
+
+      result << {
+        package: parts[0],
+        version: parts[1],
+      }
+    end
+
+    { status: result }
+  end
+end
+
+if __FILE__ == $PROGRAM_NAME
+  ChocolateyStatusTask.run
+end


### PR DESCRIPTION
Add a task to list current packages:

```
C:\> bolt task run chocolatey::status -t localhost
Started on localhost...
Finished on localhost:
{"status":[{"package":"chocolatey","version":"0.11.3"},{"package":"puppet-bolt","version":"3.20.0"}]}
Successful on 1 target: localhost
Ran on 1 target in 2.6 sec
C:\>
```

Add tasks to install, upgrade and uninstall packages:

```
C:\> bolt task run chocolatey action=install package=pdk version=2.0.0.0 -t localhost
C:\> bolt task run chocolatey action=upgrade package=pdk -t localhost
C:\> bolt task run chocolatey action=uninstall package=pdk -t localhost
```

Add a task to pin/unpin packages:

```
C:\> bolt task run chocolatey::pin action=add package=puppet-bolt -t localhost
C:\> bolt task run chocolatey::pin action=list -t localhost
Started on localhost...
Finished on localhost:
{"status":[{"package":"puppet-bolt","version":"3.20.0"}]}
Successful on 1 target: localhost
Ran on 1 target in 2.6 sec
C:\> bolt task run chocolatey::pin action=remove package=pdk -t localhost
```

Add a task to list outdated packages:

```
C:\> bolt task run chocolatey::outdated -t localhost
Started on localhost...
Finished on localhost:
{"status":[{"package":"puppet-bolt","version":"3.20.0","available_version":"3.21.0","pinned":false}]}
Successful on 1 target: localhost
Ran on 1 target in 10.14 sec
C:\>
```