### PR TITLE
(MODULES-11206) Update dependencies to allow stdlib 8.x

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.6.0 < 8.0.0"
+      "version_requirement": ">= 4.6.0 < 9.0.0"
     },
     {
       "name": "puppetlabs/powershell",


### PR DESCRIPTION
This commit updates the dependency on `puppetlabs/stdlib` to allow
for 8.x versions.