### PR TITLE
(GH-283) Fix deprecation error

### DIFF
--- a/lib/puppet_x/chocolatey/chocolatey_common.rb
+++ b/lib/puppet_x/chocolatey/chocolatey_common.rb
@@ -61,7 +61,9 @@ module PuppetX::Chocolatey::ChocolateyCommon
   #
   # @return [String] Semver string of Chocolatey version
   def choco_version
-    @chocoversion ||= strip_beta_from_version(Facter.value('chocolateyversion') || PuppetX::Chocolatey::ChocolateyVersion.version)
+    version_fact = Facter.value('chocolateyversion')
+    @chocoversion ||= strip_beta_from_version((version_fact == '0' ? nil : version_fact) || PuppetX::Chocolatey::ChocolateyVersion.version)
+    @chocoversion
   end
   module_function :choco_version
 

--- a/spec/unit/puppet/provider/package/chocolatey_spec.rb
+++ b/spec/unit/puppet/provider/package/chocolatey_spec.rb
@@ -386,7 +386,7 @@ chocolatey|19.0
       it 'uses install command with held package' do
         allow(provider.class).to receive(:compiled_choco?).and_return(true)
         expect(Facter).to receive(:value).with('choco_install_path').and_return('c:\dude')
-        expect(Facter).to receive(:value).with('chocolateyversion').and_return(first_compiled_choco_version)
+        expect(Facter).to receive(:value).with('chocolateyversion').and_return(first_compiled_choco_version).twice
         allow(PuppetX::Chocolatey::ChocolateyCommon).to receive(:file_exists?).with('c:\dude\bin\choco.exe').and_return(true)
         # unhold is called in installs on compiled choco
         allow(Puppet::Util::Execution).to receive(:execute)

--- a/spec/unit/puppet_x/chocolatey/chocolatey_common_spec.rb
+++ b/spec/unit/puppet_x/chocolatey/chocolatey_common_spec.rb
@@ -49,7 +49,9 @@ describe 'Chocolatey Common' do
     let(:choco_install_loc) { 'c:\dude' }
 
     before(:each) do
-      expect(Facter).to receive(:value).with('choco_install_path').and_return(choco_install_loc)
+      expected_version = '0.9.9.0.1'
+      expect(Facter).to receive(:value).with('choco_install_path').and_return(choco_install_loc).once
+      expect(Facter).to receive(:value).with('chocolateyversion').and_return(expected_version).once
     end
 
     it 'returns the normal config file location when found' do


### PR DESCRIPTION
# Context

Fixes #283 

In situations where the resource described in the manifest includes a version in its `ensure` property and `choco` v1 or above is installed, puppet runs would fail. This was happening of an issue where the version of chocolatey was not being properly derived by `choco_version`.

In turn, would cause `compiled_choco` to return false causing the module to default to using `choco update` rather than `choco upgrade`.

# What has changed?

This PR fixes that by ensuring that the `choco_version` method returns the correct puppet version.

We can now observe the correct behaviour, even when the `chocolateyversion` fact has not been populated.

```bash
Debug: Facter: resolving fact with user_query: chocolateyversion
Debug: Facter: Searching fact: chocolateyversion in file: chocolateyversion.rb
Debug: Facter: List of resolvable facts: [#<Facter::SearchedFact:0x000001f3c8dae6a8 @name="chocolateyversion", @fact_class=nil, @user_query="chocolateyversion", @type=:custom, @file=nil>]
Debug: Facter: Searching fact: chocolateyversion in core facts and external facts
Debug: Facter: Loading all internal facts
Debug: Facter: Loading external facts
Debug: Facter: fact "chocolateyversion" has resolved to: 0
Debug: Executing: 'C:\ProgramData\chocolatey\choco.exe upgrade pwsh --version 7.2.2 -y  --ignore-package-exit-codes --no-progress'
```