### PR TITLE
pdksync - (GH-cat-12) Add Support for Redhat 9

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -40,6 +40,12 @@
         "2019",
         "2022"
       ]
+    },
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "9"
+      ]
     }
   ],
   "requirements": [


### PR DESCRIPTION
(GH-cat-12) Add Support for Redhat 9
pdk version: `2.3.0` 
