### PR TITLE
(MAINT) Dropping of support for windows 7,8.1, 2008/2008R2 (Server)

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -29,11 +29,7 @@
     {
       "operatingsystem": "Windows",
       "operatingsystemrelease": [
-        "7",
-        "8.1",
         "10",
-        "2008",
-        "2008 R2",
         "2012",
         "2012 R2",
         "2016",


### PR DESCRIPTION
Prior to this commit the metadata.json file for this module listed OSs that are not supported by puppet agent as supported. This commit aims to refactor the metadata.json file to only list OSs that are supported by puppet agent.

In this commit:
- Support for Windows 7 and 8.1 was dropped.
- Support for Windows Server 2008 and 2008 R2 was dropped.

The list of supported OSs can be found here:
https://puppet.com/docs/pe/2021.7/supported_operating_systems.html