### PR TITLE
(CONT-708) Set all execute's to run with sensitive

### DIFF
--- a/lib/puppet/provider/chocolateyconfig/windows.rb
+++ b/lib/puppet/provider/chocolateyconfig/windows.rb
@@ -146,7 +146,7 @@ Puppet::Type.type(:chocolateyconfig).provide(:windows) do
     end
 
     begin
-      Puppet::Util::Execution.execute([command(:chocolatey), *args])
+      Puppet::Util::Execution.execute([command(:chocolatey), *args], sensitive: true)
     rescue Puppet::ExecutionFailure => e
       raise Puppet::Error, "An error occurred running choco. Unable to set Chocolateyconfig[#{name}]: #{e}"
     end

--- a/lib/puppet/provider/chocolateyfeature/windows.rb
+++ b/lib/puppet/provider/chocolateyfeature/windows.rb
@@ -122,7 +122,7 @@ Puppet::Type.type(:chocolateyfeature).provide(:windows) do
     args << command
     args << '--name' << resource[:name]
 
-    Puppet::Util::Execution.execute([command(:chocolatey), *args], sensitive: true)
+    Puppet::Util::Execution.execute([command(:chocolatey), *args])
 
     @property_hash.clear
     @property_flush.clear

--- a/lib/puppet/provider/chocolateyfeature/windows.rb
+++ b/lib/puppet/provider/chocolateyfeature/windows.rb
@@ -122,7 +122,7 @@ Puppet::Type.type(:chocolateyfeature).provide(:windows) do
     args << command
     args << '--name' << resource[:name]
 
-    Puppet::Util::Execution.execute([command(:chocolatey), *args])
+    Puppet::Util::Execution.execute([command(:chocolatey), *args], sensitive: true)
 
     @property_hash.clear
     @property_flush.clear

--- a/lib/puppet/provider/chocolateysource/windows.rb
+++ b/lib/puppet/provider/chocolateysource/windows.rb
@@ -176,7 +176,7 @@ Puppet::Type.type(:chocolateysource).provide(:windows) do
 
   def flush
     args = []
-    opts = {}
+    opts = { sensitive: true }
 
     args << 'source'
 
@@ -228,7 +228,7 @@ Puppet::Type.type(:chocolateysource).provide(:windows) do
 
     if property_ensure == :present
       begin
-        Puppet::Util::Execution.execute([command(:chocolatey), 'source', 'enable', '--name', resource[:name]])
+        Puppet::Util::Execution.execute([command(:chocolatey), 'source', 'enable', '--name', resource[:name]], sensitive: true)
       rescue Puppet::ExecutionFailure
         raise Puppet::Error, "An error occurred running choco. Unable to set Chocolatey source configuration for #{inspect}"
       end

--- a/lib/puppet/provider/chocolateysource/windows.rb
+++ b/lib/puppet/provider/chocolateysource/windows.rb
@@ -199,7 +199,8 @@ Puppet::Type.type(:chocolateysource).provide(:windows) do
       if resource[:user] && resource[:user] != ''
         args << '--user' << resource[:user]
         args << '--password' << resource[:password]
-        opts = { sensitive: true, failonfail: true, combine: true }
+        opts[:failonfail] = true
+        opts[:combine] = true
       end
 
       choco_gem_version = Gem::Version.new(PuppetX::Chocolatey::ChocolateyCommon.choco_version)

--- a/lib/puppet/provider/package/chocolatey.rb
+++ b/lib/puppet/provider/package/chocolatey.rb
@@ -276,7 +276,7 @@ Puppet::Type.type(:package).provide(:chocolatey, parent: Puppet::Provider::Packa
       pins = []
       pin_output = nil unless choco_exe
       # don't add -r yet, as there is an issue in 0.9.9.9/0.9.9.10 that returns full list plus pins
-      pin_output = Puppet::Util::Execution.execute([command(:chocolatey), 'pin', 'list']) if choco_exe
+      pin_output = Puppet::Util::Execution.execute([command(:chocolatey), 'pin', 'list'], sensitive: true) if choco_exe
       pin_output&.split("\n")&.each { |pin| pins << pin.split('|')[0] }
 
       execpipe(listcmd) do |process|

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -26,10 +26,10 @@ class chocolatey::config {
     }
 
     exec { "chocolatey_autouninstaller_${_enable_autouninstaller}":
-      path        => $::path,
+      path        => $facts['path'],
       command     => "${_choco_exe_path} feature -r ${_enable_autouninstaller} -n autoUninstaller",
       unless      => "cmd.exe /c ${_choco_exe_path} feature list -r | findstr /B /I /C:\"autoUninstaller - [${_enable_autouninstaller}d]\"",
-      environment => ["ChocolateyInstall=${::chocolatey::choco_install_location}"]
+      environment => ["ChocolateyInstall=${chocolatey::choco_install_location}"],
     }
   }
 # lint:endignore

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -76,17 +76,17 @@
 class chocolatey (
   Stdlib::Windowspath $choco_install_location = $facts['choco_install_path'],
   Boolean $use_7zip                           = false,
-  String $seven_zip_download_url              = 'https://chocolatey.org/7za.exe',
+  String[1] $seven_zip_download_url           = 'https://chocolatey.org/7za.exe',
   Integer $choco_install_timeout_seconds      = 1500,
   Stdlib::Filesource $chocolatey_download_url = 'https://chocolatey.org/api/v2/package/chocolatey/',
   Boolean $enable_autouninstaller             = true,
-  $log_output                                 = false,
-  $chocolatey_version                         = $facts['chocolateyversion'],
-  $install_proxy                              = undef,
+  Boolean $log_output                         = false,
+  String[1] $chocolatey_version               = $facts['chocolateyversion'],
+  Optional[String[1]] $install_proxy          = undef,
 ) {
-  class { '::chocolatey::install': }
-  -> class { '::chocolatey::config': }
+  class { 'chocolatey::install': }
+  -> class { 'chocolatey::config': }
 
-  contain '::chocolatey::install'
-  contain '::chocolatey::config'
+  contain 'chocolatey::install'
+  contain 'chocolatey::config'
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,28 +4,28 @@
 class chocolatey::install {
   assert_private()
 
-  $install_proxy = $::chocolatey::install_proxy
+  $install_proxy = $chocolatey::install_proxy
   $_install_proxy = $install_proxy ? {
     undef   => '$false',
     default => "'${install_proxy}'",
   }
-  $_download_url           = $::chocolatey::chocolatey_download_url
-  $seven_zip_download_url  = $::chocolatey::seven_zip_download_url
+  $_download_url           = $chocolatey::chocolatey_download_url
+  $seven_zip_download_url  = $chocolatey::seven_zip_download_url
   $seven_zip_exe           = "${facts['choco_temp_dir']}\\7za.exe"
 
   # lint:ignore:only_variable_string
-  if "${_download_url}" =~ /^http(s)?:\/\/.*api\/v2\/package.*\/$/ and "${::chocolatey::chocolatey_version}" =~ /\d+\./ {
+  if "${_download_url}" =~ /^http(s)?:\/\/.*api\/v2\/package.*\/$/ and "${chocolatey::chocolatey_version}" =~ /\d+\./ {
     # Assume a nuget server source and we want to download a specific version instead the most current
-    $download_url = "${_download_url}${::chocolatey::chocolatey_version}"
+    $download_url = "${_download_url}${chocolatey::chocolatey_version}"
   } else {
     $download_url = $_download_url
   }
   # lint:endignore
 
-  if $::chocolatey::use_7zip {
+  if $chocolatey::use_7zip {
     $unzip_type = '7zip'
     file { $seven_zip_exe:
-      ensure  => present,
+      ensure  => file,
       source  => $seven_zip_download_url,
       replace => false,
       mode    => '0755',
@@ -44,11 +44,11 @@ class chocolatey::install {
 
   exec { 'install_chocolatey_official':
     command     => template('chocolatey/InstallChocolatey.ps1.erb'),
-    creates     => "${::chocolatey::choco_install_location}\\bin\\choco.exe",
+    creates     => "${chocolatey::choco_install_location}\\bin\\choco.exe",
     provider    => powershell,
-    timeout     => $::chocolatey::choco_install_timeout_seconds,
-    logoutput   => $::chocolatey::log_output,
-    environment => ["ChocolateyInstall=${::chocolatey::choco_install_location}"],
+    timeout     => $chocolatey::choco_install_timeout_seconds,
+    logoutput   => $chocolatey::log_output,
+    environment => ["ChocolateyInstall=${chocolatey::choco_install_location}"],
     require     => Registry_value['ChocolateyInstall environment value'],
   }
 }

--- a/spec/unit/puppet/provider/chocolateyconfig/windows_spec.rb
+++ b/spec/unit/puppet/provider/chocolateyconfig/windows_spec.rb
@@ -260,7 +260,8 @@ describe Puppet::Type.type(:chocolateyconfig).provider(:windows) do
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'config', 'set',
                                                                  '--name', resource_name,
-                                                                 '--value', resource_value])
+                                                                 '--value', resource_value],
+                                                                 sensitive: true)
 
       resource.flush
     end
@@ -271,7 +272,8 @@ describe Puppet::Type.type(:chocolateyconfig).provider(:windows) do
       # PuppetX::Chocolatey::ChocolateyCommon.allow(:choco_version).returns(minimum_supported_version)
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'config', 'unset',
-                                                                 '--name', resource_name])
+                                                                 '--name', resource_name],
+                                                                 sensitive: true)
 
       resource.flush
     end
@@ -281,7 +283,8 @@ describe Puppet::Type.type(:chocolateyconfig).provider(:windows) do
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'config', 'set',
                                                                  '--name', resource_name,
-                                                                 '--value', resource_value]).and_raise(Puppet::ExecutionFailure, 'Nooooo')
+                                                                 '--value', resource_value],
+                                                                 sensitive: true).and_raise(Puppet::ExecutionFailure, 'Nooooo')
 
       expect { resource.flush }.to raise_error(Puppet::Error, %r{Unable to set Chocolateyconfig})
     end

--- a/spec/unit/puppet/provider/chocolateysource/windows_spec.rb
+++ b/spec/unit/puppet/provider/chocolateysource/windows_spec.rb
@@ -521,11 +521,13 @@ describe provider do
                                                                  'source', 'add',
                                                                  '--name', resource_name,
                                                                  '--source', resource_location,
-                                                                 '--priority', '0'], {})
+                                                                 '--priority', '0'],
+                                                                 sensitive: true)
 
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'source', 'enable',
-                                                                 '--name', 'yup'])
+                                                                 '--name', 'yup'],
+                                                                 sensitive: true)
 
       resource.flush
     end
@@ -552,7 +554,8 @@ describe provider do
 
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'source', 'enable',
-                                                                 '--name', resource_name])
+                                                                 '--name', resource_name],
+                                                                 sensitive: true)
 
       resource.flush
     end
@@ -564,11 +567,13 @@ describe provider do
                                                                  'source', 'add',
                                                                  '--name', resource_name,
                                                                  '--source', resource_location,
-                                                                 '--priority', resource_priority], {})
+                                                                 '--priority', resource_priority],
+                                                                 sensitive: true)
 
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'source', 'enable',
-                                                                 '--name', resource_name])
+                                                                 '--name', resource_name],
+                                                                 sensitive: true)
 
       resource.flush
     end
@@ -583,11 +588,12 @@ describe provider do
                                                                  '--source', resource_location,
                                                                  '--bypass-proxy',
                                                                  '--priority', '0'],
-                                                                {})
+                                                                 sensitive: true)
 
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'source', 'enable',
-                                                                 '--name', resource_name])
+                                                                 '--name', resource_name],
+                                                                 sensitive: true)
 
       resource.flush
     end
@@ -602,11 +608,12 @@ describe provider do
                                                                  '--source', resource_location,
                                                                  '--allow-self-service',
                                                                  '--priority', '0'],
-                                                                {})
+                                                                 sensitive: true)
 
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'source', 'enable',
-                                                                 '--name', resource_name])
+                                                                 '--name', resource_name],
+                                                                 sensitive: true)
 
       resource.flush
     end
@@ -621,11 +628,12 @@ describe provider do
                                                                  '--source', resource_location,
                                                                  '--admin-only',
                                                                  '--priority', '0'],
-                                                                {})
+                                                                 sensitive: true)
 
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'source', 'enable',
-                                                                 '--name', resource_name])
+                                                                 '--name', resource_name],
+                                                                 sensitive: true)
 
       resource.flush
     end
@@ -645,7 +653,8 @@ describe provider do
 
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'source', 'enable',
-                                                                 '--name', resource_name])
+                                                                 '--name', resource_name],
+                                                                 sensitive: true)
 
       resource.flush
     end
@@ -664,7 +673,8 @@ describe provider do
 
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'source', 'enable',
-                                                                 '--name', resource_name])
+                                                                 '--name', resource_name],
+                                                                 sensitive: true)
 
       resource.flush
     end
@@ -677,11 +687,13 @@ describe provider do
                                                                  'source', 'add',
                                                                  '--name', resource_name,
                                                                  '--source', resource_location,
-                                                                 '--priority', '0'], {})
+                                                                 '--priority', '0'],
+                                                                 sensitive: true)
 
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'source', 'enable',
-                                                                 '--name', resource_name])
+                                                                 '--name', resource_name],
+                                                                 sensitive: true)
 
       resource.flush
     end
@@ -695,11 +707,13 @@ describe provider do
                                                                  '--name', resource_name,
                                                                  '--source', resource_location,
                                                                  '--bypass-proxy',
-                                                                 '--priority', '0'], {})
+                                                                 '--priority', '0'],
+                                                                 sensitive: true)
 
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'source', 'enable',
-                                                                 '--name', resource_name])
+                                                                 '--name', resource_name],
+                                                                 sensitive: true)
 
       resource.flush
     end
@@ -712,11 +726,13 @@ describe provider do
                                                                  'source', 'add',
                                                                  '--name', resource_name,
                                                                  '--source', resource_location,
-                                                                 '--priority', '0'], {})
+                                                                 '--priority', '0'],
+                                                                 sensitive: true)
 
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'source', 'enable',
-                                                                 '--name', resource_name])
+                                                                 '--name', resource_name],
+                                                                 sensitive: true)
 
       resource.flush
     end
@@ -730,11 +746,13 @@ describe provider do
                                                                  '--name', resource_name,
                                                                  '--source', resource_location,
                                                                  '--allow-self-service',
-                                                                 '--priority', '0'], {})
+                                                                 '--priority', '0'],
+                                                                 sensitive: true)
 
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'source', 'enable',
-                                                                 '--name', resource_name])
+                                                                 '--name', resource_name],
+                                                                 sensitive: true)
 
       resource.flush
     end
@@ -748,11 +766,13 @@ describe provider do
                                                                  '--name', resource_name,
                                                                  '--source', resource_location,
                                                                  '--admin-only',
-                                                                 '--priority', '0'], {})
+                                                                 '--priority', '0'],
+                                                                 sensitive: true)
 
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'source', 'enable',
-                                                                 '--name', resource_name])
+                                                                 '--name', resource_name],
+                                                                 sensitive: true)
 
       resource.flush
     end
@@ -764,11 +784,12 @@ describe provider do
                                                                  '--name', resource_name,
                                                                  '--source', resource_location,
                                                                  '--priority', '0'],
-                                                                {})
+                                                                 sensitive: true)
 
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'source', 'enable',
-                                                                 '--name', resource_name])
+                                                                 '--name', resource_name],
+                                                                 sensitive: true)
 
       resource.flush
     end
@@ -780,11 +801,12 @@ describe provider do
                                                                  '--name', resource_name,
                                                                  '--source', resource_location,
                                                                  '--priority', '0'],
-                                                                {})
+                                                                 sensitive: true)
 
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'source', 'enable',
-                                                                 '--name', resource_name])
+                                                                 '--name', resource_name],
+                                                                 sensitive: true)
 
       resource.flush
     end
@@ -797,11 +819,12 @@ describe provider do
                                                                  'source', 'add',
                                                                  '--name', resource_name,
                                                                  '--source', resource_location],
-                                                                {})
+                                                                 sensitive: true)
 
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'source', 'enable',
-                                                                 '--name', resource_name])
+                                                                 '--name', resource_name],
+                                                                 sensitive: true)
 
       resource.flush
     end
@@ -814,7 +837,7 @@ describe provider do
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'source', 'disable',
                                                                  '--name', 'chocolatey'],
-                                                                {})
+                                                                 sensitive: true)
 
       resource.flush
     end
@@ -827,11 +850,12 @@ describe provider do
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'source', 'remove',
                                                                  '--name', resource_name],
-                                                                {})
+                                                                 sensitive: true)
 
       expect(Puppet::Util::Execution).to receive(:execute).with([provider_class.command(:chocolatey),
                                                                  'source', 'enable',
-                                                                 '--name', 'yup']).never
+                                                                 '--name', 'yup'],
+                                                                 sensitive: true).never
 
       resource.flush
     end
@@ -842,7 +866,8 @@ describe provider do
                                                                  'source', 'add',
                                                                  '--name', resource_name,
                                                                  '--source', resource_location,
-                                                                 '--priority', '0'], {}).and_raise(Puppet::ExecutionFailure, 'Nooooo')
+                                                                 '--priority', '0'],
+                                                                 sensitive: true).and_raise(Puppet::ExecutionFailure, 'Nooooo')
 
       expect { resource.flush }.to raise_error(Puppet::Error, %r{Unable to set Chocolatey source})
     end


### PR DESCRIPTION
As it stands certain sensitive parameters are being revealed within error and debug messages. This should prevent that.
Setting all to sensitive in order to be thorough, no reason not to.