### PR TITLE
(CAT-1274) - Fixing rubocop smells

### DIFF
--- a/spec/tasks/chocolatey_outdated_task_spec.rb
+++ b/spec/tasks/chocolatey_outdated_task_spec.rb
@@ -9,8 +9,7 @@ describe ChocolateyOutdatedTask do
   before(:each) do
     sucess_status = double
     allow(sucess_status).to receive(:==).with(0).and_return(true)
-    allow(sucess_status).to receive(:exited?).and_return(true)
-    allow(sucess_status).to receive(:exitstatus).and_return(0)
+    allow(sucess_status).to receive_messages(exited?: true, exitstatus: 0)
     allow(Open3).to receive(:capture2).with('choco', 'outdated', '--no-color', '--limit-output').and_return([<<~OUTPUT, sucess_status])
       puppet-bolt|3.20.0|3.21.0|false
     OUTPUT

--- a/spec/tasks/chocolatey_pin_task_spec.rb
+++ b/spec/tasks/chocolatey_pin_task_spec.rb
@@ -12,8 +12,7 @@ describe ChocolateyPinTask do
   let(:sucess_status) do
     res = double
     allow(res).to receive(:==).with(0).and_return(true)
-    allow(res).to receive(:exited?).and_return(true)
-    allow(res).to receive(:exitstatus).and_return(0)
+    allow(res).to receive_messages(exited?: true, exitstatus: 0)
     res
   end
 

--- a/spec/tasks/chocolatey_status_task_spec.rb
+++ b/spec/tasks/chocolatey_status_task_spec.rb
@@ -9,8 +9,7 @@ describe ChocolateyStatusTask do
   before(:each) do
     sucess_status = double
     allow(sucess_status).to receive(:==).with(0).and_return(true)
-    allow(sucess_status).to receive(:exited?).and_return(true)
-    allow(sucess_status).to receive(:exitstatus).and_return(0)
+    allow(sucess_status).to receive_messages(exited?: true, exitstatus: 0)
     allow(Open3).to receive(:capture2).with('choco', 'list', '--local-only', '--no-color', '--limit-output').and_return([<<~OUTPUT, sucess_status])
       chocolatey|0.11.3
       puppet-bolt|3.20.0

--- a/spec/tasks/chocolatey_task_spec.rb
+++ b/spec/tasks/chocolatey_task_spec.rb
@@ -12,8 +12,7 @@ describe ChocolateyTask do
   let(:sucess_status) do
     res = double
     allow(res).to receive(:==).with(0).and_return(true)
-    allow(res).to receive(:exited?).and_return(true)
-    allow(res).to receive(:exitstatus).and_return(0)
+    allow(res).to receive_messages(exited?: true, exitstatus: 0)
     res
   end
 

--- a/spec/unit/puppet/provider/package/chocolatey_spec.rb
+++ b/spec/unit/puppet/provider/package/chocolatey_spec.rb
@@ -417,8 +417,7 @@ describe Puppet::Type.type(:package).provider(:chocolatey) do
   context 'when uninstalling' do
     context 'with compiled choco client' do
       before :each do
-        allow(provider).to receive(:on_hold?).and_return(false)
-        allow(provider).to receive(:use_package_exit_codes_feature_enabled?).and_return(false)
+        allow(provider).to receive_messages(on_hold?: false, use_package_exit_codes_feature_enabled?: false)
         allow(provider.class).to receive(:compiled_choco?).and_return(true)
         allow(PuppetX::Chocolatey::ChocolateyVersion).to receive(:version).and_return(first_compiled_choco_version)
         # unhold is called in installs on compiled choco
@@ -501,8 +500,7 @@ describe Puppet::Type.type(:package).provider(:chocolatey) do
   context 'when updating' do
     context 'with compiled choco client' do
       before :each do
-        allow(provider).to receive(:on_hold?).and_return(false)
-        allow(provider).to receive(:use_package_exit_codes_feature_enabled?).and_return(false)
+        allow(provider).to receive_messages(on_hold?: false, use_package_exit_codes_feature_enabled?: false)
         allow(provider.class).to receive(:compiled_choco?).and_return(true)
         allow(PuppetX::Chocolatey::ChocolateyVersion).to receive(:version).and_return(first_compiled_choco_version)
         # unhold is called in installs on compiled choco


### PR DESCRIPTION
## Summary
Fixing rubocop smells

## Additional Context
- N/A

## Related Issues (if any)
- N/A

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)