### PR TITLE
pdksync - (CAT-1366) - fFix issue url from old jira to github

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "source": "https://github.com/puppetlabs/puppetlabs-chocolatey",
   "project_page": "https://github.com/puppetlabs/puppetlabs-chocolatey",
-  "issues_url": "https://tickets.puppetlabs.com/browse/MODULES",
+  "issues_url": "https://github.com/puppetlabs/puppetlabs-chocolatey/issues",
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
(CAT-1366) - fFix issue url from old jira to github
pdk version: `2.7.1` 
