### PR TITLE
[CAT-1382] : Fixing CI failure due to rubocop

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -121,7 +121,7 @@ RSpec/ExpectInHook:
 # Offense count: 1
 # Configuration parameters: Include, CustomTransform, IgnoreMethods, SpecSuffixOnly.
 # Include: **/*_spec*rb*, **/spec/**/*
-RSpec/FilePath:
+RSpec/SpecFilePathSuffix:
   Exclude:
     - 'spec/unit/facter/choco_temp_dir.rb'
 

--- a/spec/unit/facter/choco_temp_dir.rb
+++ b/spec/unit/facter/choco_temp_dir.rb
@@ -21,7 +21,7 @@ describe 'choco_temp_dir fact' do
   end
 
   it 'returns the TEMP directory' do
-    expect(PuppetX::Chocolatey::ChocolateyInstall).to receive(:temp_dir).and_return('waffles')
+    allow(PuppetX::Chocolatey::ChocolateyInstall).to receive(:temp_dir).and_return('waffles')
 
     expect(fact_value).to eq('waffles')
   end

--- a/spec/unit/puppet/provider/chocolateysource/windows_spec.rb
+++ b/spec/unit/puppet/provider/chocolateysource/windows_spec.rb
@@ -250,7 +250,7 @@ describe provider do
     end
 
     it 'returns nil source when element it nil' do
-      expect(provider_class.get_source(nil)).to be == {}
+      expect(provider_class.get_source(nil)).to eq({})
     end
 
     it 'converts an element to a source' do

--- a/spec/unit/puppet/provider/package/chocolatey_spec.rb
+++ b/spec/unit/puppet/provider/package/chocolatey_spec.rb
@@ -194,7 +194,7 @@ describe Puppet::Type.type(:package).provider(:chocolatey) do
     end
 
     it 'returns nil source when element is nil' do
-      expect(provider.get_choco_feature(nil)).to be == {}
+      expect(provider.get_choco_feature(nil)).to eq({})
     end
 
     it 'converts an element to a source' do


### PR DESCRIPTION
## Summary
Fixing CI failure in rubocop

## Additional Context
- [x] New version released in rubocop-rspec ([v2.24.0](https://github.com/rubocop/rubocop-rspec/releases/tag/v2.24.0)) caused regression in linting.
```
Add RSpec/MetadataStyle and RSpec/EmptyMetadata cops.
```

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)