### PR TITLE
CAT-1382 - Fixing rubocop issues due to new change in rubocop-rspec(v…

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -120,8 +120,8 @@ RSpec/ExpectInHook:
 
 # Offense count: 1
 # Configuration parameters: Include, CustomTransform, IgnoreMethods, SpecSuffixOnly.
-# Include: **/*_spec*rb*, **/spec/**/*
-RSpec/FilePath:
+# # Include: **/*_spec*rb*, **/spec/**/*
+RSpec/SpecFilePathSuffix:
   Exclude:
     - 'spec/unit/facter/choco_temp_dir.rb'
 

--- a/spec/unit/puppet/provider/chocolateysource/windows_spec.rb
+++ b/spec/unit/puppet/provider/chocolateysource/windows_spec.rb
@@ -250,7 +250,7 @@ describe provider do
     end
 
     it 'returns nil source when element it nil' do
-      expect(provider_class.get_source(nil)).to be == {}
+      expect(provider_class.get_source(nil)).to be eq({})
     end
 
     it 'converts an element to a source' do

--- a/spec/unit/puppet/provider/package/chocolatey_spec.rb
+++ b/spec/unit/puppet/provider/package/chocolatey_spec.rb
@@ -194,7 +194,7 @@ describe Puppet::Type.type(:package).provider(:chocolatey) do
     end
 
     it 'returns nil source when element is nil' do
-      expect(provider.get_choco_feature(nil)).to be == {}
+      expect(provider.get_choco_feature(nil)).to be eq({})
     end
 
     it 'converts an element to a source' do


### PR DESCRIPTION
…2.24.0)

## Summary
Fixing rubocop issues due to new change in rubocop-rspec

## Additional Context
Add any additional context about the problem here. 
- [ ] New version released in rubocop-rspec ([v2.24.0](https://github.com/rubocop/rubocop-rspec/releases/tag/v2.24.0)) caused regression in linting.
```
Split RSpec/FilePath into RSpec/SpecFilePathSuffix and RSpec/SpecFilePathFormat. RSpec/FilePath cop is enabled by default, the two new cops are pending and need to be enabled explicitly. (@ydah)
```

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)