### PR TITLE
Running as Bolt Tasks fails

### DIFF
--- a/tasks/init.rb
+++ b/tasks/init.rb
@@ -8,7 +8,7 @@ require_relative '../../ruby_task_helper/files/task_helper'
 
 # Manage installing, upgrading and uninstalling packages
 class ChocolateyTask < TaskHelper
-  def task(action: nil, package: nil, version: nil, **args)
+  def task(action: nil, package: nil, version: nil, **_args)
     command = [
       'choco',
       action,

--- a/tasks/init.rb
+++ b/tasks/init.rb
@@ -8,7 +8,7 @@ require_relative '../../ruby_task_helper/files/task_helper'
 
 # Manage installing, upgrading and uninstalling packages
 class ChocolateyTask < TaskHelper
-  def task(action: nil, package: nil, version: nil)
+  def task(action: nil, package: nil, version: nil, **args)
     command = [
       'choco',
       action,


### PR DESCRIPTION
## Summary
Fixing the ability to use this a puppet bolt task.

Reproduction Steps:
1. Init new Bolt Project
2. Add Module `puppetlabs-chocolatey`
3. Run `bolt task run chocolatey --log-level trace --targets localhost action="install" package="notepadplusplus"`

Error Output:
```json
{
  "target": "localhost",
  "action": "task",
  "object": "chocolatey",
  "status": "failure",
  "value": {
    "_error": {
      "kind": "ArgumentError",
      "msg": "unknown keywords: :_task, :_installdir",
      "details": {
        "backtrace": [
          "C:/Users/REDACTED/AppData/Local/Temp/wo3sspbp.4hi/chocolatey/tasks/init.rb:11:in `task'",
          "C:/Users/REDACTED/AppData/Local/Temp/wo3sspbp.4hi/ruby_task_helper/files/task_helper.rb:58:in `run'",
          "C:/Users/REDACTED/AppData/Local/Temp/wo3sspbp.4hi/chocolatey/tasks/init.rb:37:in `<main>'"
        ]
      }
    }
  }
}
```

## Additional Context
```
Running task chocolatey with '{"action":"install","package":"notepadplusplus","_task":"chocolatey"}' on ["localhost"]
```

## Related Issues (if any)
None

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [X] Manually verified. (For example `puppet apply`)