### PR TITLE
Install option escaping

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,37 @@ package {'mysql':
 }
 ~~~
 
+You can also use `chocholatey::install_options()` to perform the neccessary
+escaping, and splitting, of arguments.
+
+~~~puppet
+package {'mysql':
+  ensure          => latest,
+  provider        => 'chocolatey',
+  install_options => chocolatey::install_options(
+    '-override',
+    '-installArgs',
+    '/INSTALLDIR="C:\Program Files\somewhere"',
+  ),
+}
+~~~
+
+The directory name itself can be escaped with `chocolatey::escape()`.
+
+~~~puppet
+$install_dir = 'C:\Program Files\somewhere'
+
+package {'mysql':
+  ensure          => latest,
+  provider        => 'chocolatey',
+  install_options => chocolatey::install_options(
+    '-override',
+    '-installArgs',
+    "/INSTALLDIR=$(chocolatey::escape($install_dir))",
+  ),
+}
+~~~
+
 **Note:** The above is for Chocolatey v0.9.9+. You may need to look for an
 alternative method to pass args if you have 0.9.8.x and below.
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -21,6 +21,11 @@
 * [`chocolateyfeature`](#chocolateyfeature): Allows managing features for Chocolatey. Features are configuration that act as feature flippers to turn on or off certain aspects of how Cho
 * [`chocolateysource`](#chocolateysource): Allows managing sources for Chocolatey. A source can be a folder, a CIFS share, a NuGet Http OData feed, or a full Package Gallery. Learn mor
 
+### Functions
+
+* [`chocolatey::escape`](#chocolatey--escape): Perform escaping and quoting for an install option
+* [`chocolatey::install_options`](#chocolatey--install_options): Perform escaping, and splitting of a number of install options
+
 ### Tasks
 
 * [`init`](#init): Manage a package
@@ -403,6 +408,76 @@ Default value: `''`
 
 The specific backend to use for this `chocolateysource` resource. You will seldom need to specify this --- Puppet will
 usually discover the appropriate provider for your platform.
+
+## Functions
+
+### <a name="chocolatey--escape"></a>`chocolatey::escape`
+
+Type: Puppet Language
+
+Escapes double quotes, and wraps values containing spaces in double quotes.
+
+#### `chocolatey::escape(String $option)`
+
+Escapes double quotes, and wraps values containing spaces in double quotes.
+
+Returns: `String`
+
+##### `option`
+
+Data type: `String`
+
+An install option to be escaped
+
+### <a name="chocolatey--install_options"></a>`chocolatey::install_options`
+
+Type: Puppet Language
+
+Perform escaping, and splitting of a number of install options
+
+#### Examples
+
+##### 
+
+```puppet
+package {'mysql':
+  ensure          => latest,
+  provider        => 'chocolatey',
+  install_options => chocolatey::install_options(
+    '-override',
+    '-installArgs',
+    "/INSTALLDIR=${chocolatey::escape('C:\Program Files\somewhere'}",
+  ),
+}
+```
+
+#### `chocolatey::install_options(Array[String] $options)`
+
+The chocolatey::install_options function.
+
+Returns: `Array[String]`
+
+##### Examples
+
+###### 
+
+```puppet
+package {'mysql':
+  ensure          => latest,
+  provider        => 'chocolatey',
+  install_options => chocolatey::install_options(
+    '-override',
+    '-installArgs',
+    "/INSTALLDIR=${chocolatey::escape('C:\Program Files\somewhere'}",
+  ),
+}
+```
+
+##### `options`
+
+Data type: `Array[String]`
+
+An install option to be escaped
 
 ## Tasks
 

--- a/functions/escape.pp
+++ b/functions/escape.pp
@@ -1,0 +1,11 @@
+# @summary Perform escaping and quoting for an install option
+#
+# Escapes double quotes, and wraps values containing spaces in double quotes.
+#
+# @param option
+#   An install option to be escaped
+# @return
+function chocolatey::escape(String $option) >> String {
+  $option.regsubst('"', '""', 'G')
+    .regsubst('^(.*\s.*)$', '"\1"')
+}

--- a/functions/install_options.pp
+++ b/functions/install_options.pp
@@ -1,0 +1,23 @@
+# @summary Perform escaping, and splitting of a number of install options
+#
+# @example
+#   package {'mysql':
+#     ensure          => latest,
+#     provider        => 'chocolatey',
+#     install_options => chocolatey::install_options(
+#       '-override',
+#       '-installArgs',
+#       "/INSTALLDIR=${chocolatey::escape('C:\Program Files\somewhere'}",
+#     ),
+#   }
+#
+# @param options
+#   An install option to be escaped
+# @return
+function chocolatey::install_options(Array[String] *$options) >> Array[String] {
+  $options.map |$option| {
+    chocolatey::escape($option)
+  }.reduce([]) |$memo, $option| {
+    $memo + $option.split(' ')
+  }
+}

--- a/spec/functions/escape_spec.rb
+++ b/spec/functions/escape_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'chocolatey::escape' do
+  it { is_expected.to run.with_params('-installArgs').and_return('-installArgs') }
+  it { is_expected.to run.with_params('C:\Program Files').and_return('"C:\Program Files"') }
+  it { is_expected.to run.with_params('/INSTALLDIR="C:\Program Files"').and_return('"/INSTALLDIR=""C:\Program Files"""') }
+end

--- a/spec/functions/install_options_spec.rb
+++ b/spec/functions/install_options_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'chocolatey::install_options' do
+  it {
+    is_expected.to run.with_params(
+      '-override',
+      '-installArgs',
+      '/VERYSILENT /NORESTART'
+    ).and_return(
+      [
+        '-override',
+        '-installArgs',
+        '"/VERYSILENT',
+        '/NORESTART"'
+      ]
+    )
+  }
+
+  it {
+    is_expected.to run.with_params(
+      '-override',
+      '-installArgs',
+      '/INSTALLDIR="C:\Program Files\somewhere"',
+    ).and_return(
+      [
+        '-override',
+        '-installArgs',
+        '"/INSTALLDIR=""C:\Program',
+        'Files\somewhere"""',
+      ]
+    )
+  }
+end


### PR DESCRIPTION
## Summary
Provide a detailed description of all the changes present in this pull request.

Adds two utility functions to perform the escaping, and argument splitting for `install_options`, as described in [README#Install options with spaces].

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [x] Thought process behind the implementation.

Performing argument escape processing manually becomes very messy, and error prone, especially when the exact contents of arguments are composed from parameters.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [x] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)

[README#Install options with spaces]: https://github.com/puppetlabs/puppetlabs-chocolatey#install-options-with-spaces