### PR TITLE
(DONT-MERGE) CI run on gh sourced ruby_task_helper

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,12 +3,14 @@ fixtures:
     stdlib:       'puppetlabs/stdlib'
     powershell:   'puppetlabs/powershell'
     registry:     'puppetlabs/registry'
-    ruby_task_helper: 'puppetlabs/ruby_task_helper'
   repositories:
       facts: 'https://github.com/puppetlabs/puppetlabs-facts.git'
       puppet_agent:
         repo: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
         ref: v4.13.0
       provision: 'https://github.com/puppetlabs/provision.git'
+      ruby_task_helper:
+        repo: 'https://github.com/puppetlabs/puppetlabs-ruby_task_helper.git'
+        ref: main
   symlinks:
     chocolatey: "#{source_dir}"


### PR DESCRIPTION
Testing github sourced ruby_task_helper through module CI. DO NOT MERGE.
