### PR TITLE
changed File.read on File.open, because read didn't correct open xml …

### DIFF
--- a/lib/puppet/provider/chocolateyconfig/windows.rb
+++ b/lib/puppet/provider/chocolateyconfig/windows.rb
@@ -46,7 +46,7 @@ Puppet::Type.type(:chocolateyconfig).provide(:windows) do
     raise Puppet::ResourceError, "An install was detected, but was unable to locate config file at #{choco_config}." unless PuppetX::Chocolatey::ChocolateyCommon.file_exists?(choco_config)
 
     Puppet.debug("Gathering sources from '#{choco_config}'.")
-    config = REXML::Document.new File.read(choco_config)
+    config = REXML::Document.new File.open(choco_config)
 
     config.elements.to_a('//add')
   end

--- a/lib/puppet/provider/chocolateyfeature/windows.rb
+++ b/lib/puppet/provider/chocolateyfeature/windows.rb
@@ -43,7 +43,7 @@ Puppet::Type.type(:chocolateyfeature).provide(:windows) do
     raise Puppet::ResourceError, "An install was detected, but was unable to locate config file at #{choco_config}." unless PuppetX::Chocolatey::ChocolateyCommon.file_exists?(choco_config)
 
     Puppet.debug("Gathering features from '#{choco_config}'.")
-    config = REXML::Document.new File.read(choco_config)
+    config = REXML::Document.new File.open(choco_config)
 
     config.elements.to_a('//feature')
   end

--- a/lib/puppet/provider/chocolateysource/windows.rb
+++ b/lib/puppet/provider/chocolateysource/windows.rb
@@ -50,7 +50,7 @@ Puppet::Type.type(:chocolateysource).provide(:windows) do
     raise Puppet::ResourceError, "An install was detected, but was unable to locate config file at #{choco_config}." unless PuppetX::Chocolatey::ChocolateyCommon.file_exists?(choco_config)
 
     Puppet.debug("Gathering sources from '#{choco_config}'.")
-    config = REXML::Document.new File.read(choco_config)
+    config = REXML::Document.new File.open(choco_config)
 
     config.elements.to_a('//source')
   end

--- a/lib/puppet/provider/package/chocolatey.rb
+++ b/lib/puppet/provider/package/chocolatey.rb
@@ -67,7 +67,7 @@ Puppet::Type.type(:package).provide(:chocolatey, parent: Puppet::Provider::Packa
     raise Puppet::ResourceError, "An install was detected, but was unable to locate config file at #{choco_config}." unless PuppetX::Chocolatey::ChocolateyCommon.file_exists?(choco_config)
 
     Puppet.debug("Gathering sources from '#{choco_config}'.")
-    config = REXML::Document.new File.read(choco_config)
+    config = REXML::Document.new File.open(choco_config)
 
     config.elements.to_a('//feature')
   end


### PR DESCRIPTION
Changed File.read to File.open, because read didn't correct open chocolatey.config in UTF-8 BOM codepage.
read this first, please [https://github.com/ruby/rexml/issues/231](url)
```
Use File.open('chocolatey.txt') or File.read('chocolatey.txt', encoding: Encoding::UTF_8) when calling REXML, please.
```
- [x] Manually verified. (For example `puppet apply`)