### PR TITLE
(CAT-2296) Update github runner image to ubuntu-24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   setup_matrix:
     name: "Setup Test Matrix"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     outputs:
       spec_matrix: ${{ steps.get-matrix.outputs.spec_matrix }}
 
@@ -40,7 +40,7 @@ jobs:
       - setup_matrix
     if: ${{ needs.setup_matrix.outputs.spec_matrix != '{}' }}
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.setup_matrix.outputs.spec_matrix)}}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   setup_matrix:
     name: "Setup Test Matrix"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     outputs:
       spec_matrix: ${{ steps.get-matrix.outputs.spec_matrix }}
     
@@ -39,7 +39,7 @@ jobs:
       - setup_matrix
     if: ${{ needs.setup_matrix.outputs.spec_matrix != '{}' }}
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.setup_matrix.outputs.spec_matrix)}}


### PR DESCRIPTION
ubuntu-20.04 is not supported anymore: https://github.com/actions/runner-images/issues/11101

## Summary
Provide a detailed description of all the changes present in this pull request.

## Additional Context
Add any additional context about the problem here. 
- [ ] Root cause and the steps to reproduce. (If applicable)
- [ ] Thought process behind the implementation.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)