### PR TITLE
(CAT-2369) Puppetcore update

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -6,9 +6,7 @@ fixtures:
     ruby_task_helper: 'puppetlabs/ruby_task_helper'
   repositories:
       facts: 'https://github.com/puppetlabs/puppetlabs-facts.git'
-      puppet_agent:
-        repo: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
-        ref: v4.13.0
+      puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
       provision: 'https://github.com/puppetlabs/provision.git'
   symlinks:
     chocolatey: "#{source_dir}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,4 +81,6 @@ jobs:
   Acceptance:
     needs: Spec
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
+    with:
+      flags: "--latest-agent"
     secrets: "inherit"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -80,4 +80,6 @@ jobs:
   Acceptance:
     needs: Spec
     uses: "puppetlabs/cat-github-actions/.github/workflows/module_acceptance.yml@main"
+    with:
+      flags: "--latest-agent"
     secrets: "inherit"

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -1,1 +1,9 @@
+--fail-on-warnings
 --relative
+--no-80chars-check
+--no-140chars-check
+--no-class_inherits_from_params_class-check
+--no-autoloader_layout-check
+--no-documentation-check
+--no-single_quote_string_with_variables-check
+--ignore-paths=.vendor/**/*.pp,.bundle/**/*.pp,pkg/**/*.pp,spec/**/*.pp,tests/**/*.pp,types/**/*.pp,vendor/**/*.pp

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,11 +1,14 @@
 ---
-require:
+plugins:
 - rubocop-performance
 - rubocop-rspec
+- rubocop-rspec_rails
+- rubocop-factory_bot
+- rubocop-capybara
 AllCops:
   NewCops: enable
   DisplayCopNames: true
-  TargetRubyVersion: '2.6'
+  TargetRubyVersion: 3.1
   Include:
   - "**/*.rb"
   Exclude:
@@ -120,6 +123,12 @@ Bundler/InsecureProtocolSource:
 Capybara/CurrentPathExpectation:
   Enabled: false
 Capybara/VisibilityMatcher:
+  Enabled: false
+FactoryBot/AttributeDefinedStatically:
+  Enabled: false
+FactoryBot/CreateList:
+  Enabled: false
+FactoryBot/FactoryClassName:
   Enabled: false
 Gemspec/DuplicatedAssignment:
   Enabled: false
@@ -295,8 +304,6 @@ Performance/UriDefaultParser:
   Enabled: false
 RSpec/Be:
   Enabled: false
-RSpec/Capybara/FeatureMethods:
-  Enabled: false
 RSpec/ContainExactly:
   Enabled: false
 RSpec/ContextMethod:
@@ -304,6 +311,8 @@ RSpec/ContextMethod:
 RSpec/ContextWording:
   Enabled: false
 RSpec/DescribeClass:
+  Enabled: false
+RSpec/Dialect:
   Enabled: false
 RSpec/EmptyHook:
   Enabled: false
@@ -320,12 +329,6 @@ RSpec/ExampleWithoutDescription:
 RSpec/ExpectChange:
   Enabled: false
 RSpec/ExpectInHook:
-  Enabled: false
-RSpec/FactoryBot/AttributeDefinedStatically:
-  Enabled: false
-RSpec/FactoryBot/CreateList:
-  Enabled: false
-RSpec/FactoryBot/FactoryClassName:
   Enabled: false
 RSpec/HooksBeforeExamples:
   Enabled: false
@@ -501,6 +504,12 @@ Capybara/SpecificFinders:
   Enabled: false
 Capybara/SpecificMatcher:
   Enabled: false
+FactoryBot/ConsistentParenthesesStyle:
+  Enabled: false
+FactoryBot/FactoryNameStyle:
+  Enabled: false
+FactoryBot/SyntaxMethods:
+  Enabled: false
 Gemspec/DeprecatedAttributeAssignment:
   Enabled: false
 Gemspec/DevelopmentDependencies:
@@ -601,27 +610,11 @@ RSpec/DuplicatedMetadata:
   Enabled: false
 RSpec/ExcessiveDocstringSpacing:
   Enabled: false
-RSpec/FactoryBot/ConsistentParenthesesStyle:
-  Enabled: false
-RSpec/FactoryBot/FactoryNameStyle:
-  Enabled: false
-RSpec/FactoryBot/SyntaxMethods:
-  Enabled: false
 RSpec/IdenticalEqualityAssertion:
   Enabled: false
 RSpec/NoExpectationExample:
   Enabled: false
 RSpec/PendingWithoutReason:
-  Enabled: false
-RSpec/Rails/AvoidSetupHook:
-  Enabled: false
-RSpec/Rails/HaveHttpStatus:
-  Enabled: false
-RSpec/Rails/InferredSpecType:
-  Enabled: false
-RSpec/Rails/MinitestAssertions:
-  Enabled: false
-RSpec/Rails/TravelAround:
   Enabled: false
 RSpec/RedundantAround:
   Enabled: false
@@ -632,6 +625,16 @@ RSpec/SortMetadata:
 RSpec/SubjectDeclaration:
   Enabled: false
 RSpec/VerifiedDoubleReference:
+  Enabled: false
+RSpecRails/AvoidSetupHook:
+  Enabled: false
+RSpecRails/HaveHttpStatus:
+  Enabled: false
+RSpecRails/InferredSpecType:
+  Enabled: false
+RSpecRails/MinitestAssertions:
+  Enabled: false
+RSpecRails/TravelAround:
   Enabled: false
 Security/CompoundHash:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,67 +1,91 @@
-source ENV['GEM_SOURCE'] || 'https://rubygems.org'
+# frozen_string_literal: true
 
-def location_for(place_or_version, fake_version = nil)
-  git_url_regex = %r{\A(?<url>(https?|git)[:@][^#]*)(#(?<branch>.*))?}
-  file_url_regex = %r{\Afile:\/\/(?<path>.*)}
+# For puppetcore, set GEM_SOURCE_PUPPETCORE = 'https://rubygems-puppetcore.puppet.com'
+gemsource_default = ENV['GEM_SOURCE'] || 'https://rubygems.org'
+gemsource_puppetcore = if ENV['PUPPET_FORGE_TOKEN']
+  'https://rubygems-puppetcore.puppet.com'
+else
+  ENV['GEM_SOURCE_PUPPETCORE'] || gemsource_default
+end
+source gemsource_default
 
-  if place_or_version && (git_url = place_or_version.match(git_url_regex))
-    [fake_version, { git: git_url[:url], branch: git_url[:branch], require: false }].compact
-  elsif place_or_version && (file_url = place_or_version.match(file_url_regex))
-    ['>= 0', { path: File.expand_path(file_url[:path]), require: false }]
+def location_for(place_or_constraint, fake_constraint = nil, opts = {})
+  git_url_regex  = /\A(?<url>(?:https?|git)[:@][^#]*)(?:#(?<branch>.*))?/
+  file_url_regex = %r{\Afile://(?<path>.*)}
+
+  if place_or_constraint && (git_url = place_or_constraint.match(git_url_regex))
+    # Git source → ignore :source, keep fake_constraint
+    [fake_constraint, { git: git_url[:url], branch: git_url[:branch], require: false }].compact
+
+  elsif place_or_constraint && (file_url = place_or_constraint.match(file_url_regex))
+    # File source → ignore :source, keep fake_constraint or default >= 0
+    [fake_constraint || '>= 0', { path: File.expand_path(file_url[:path]), require: false }]
+
   else
-    [place_or_version, { require: false }]
+    # Plain version constraint → merge opts (including :source if provided)
+    [place_or_constraint, { require: false }.merge(opts)]
+  end
+end
+
+# Print debug information if DEBUG_GEMS or VERBOSE is set
+def print_gem_statement_for(gems)
+  puts 'DEBUG: Gem definitions that will be generated:'
+  gems.each do |gem_name, gem_params|
+    puts "DEBUG:   gem #{([gem_name.inspect] + gem_params.map(&:inspect)).join(', ')}"
   end
 end
 
 group :development do
-  gem "json", '= 2.1.0',                         require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.3.0',                         require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
-  gem "json", '= 2.5.1',                         require: false if Gem::Requirement.create(['>= 3.0.0', '< 3.0.5']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.6.1',                         require: false if Gem::Requirement.create(['>= 3.1.0', '< 3.1.3']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.6.3',                         require: false if Gem::Requirement.create(['>= 3.2.0', '< 4.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "racc", '~> 1.4.0',                        require: false if Gem::Requirement.create(['>= 2.7.0', '< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "deep_merge", '~> 1.2.2',                  require: false
   gem "voxpupuli-puppet-lint-plugins", '~> 5.0', require: false
-  gem "facterdb", '~> 2.1',                      require: false
+  gem "facterdb", '~> 2.1',                      require: false if Gem::Requirement.create(['< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "facterdb", '~> 3.0',                      require: false if Gem::Requirement.create(['>= 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "metadata-json-lint", '~> 4.0',            require: false
-  gem "rspec-puppet-facts", '~> 4.0',            require: false
+  gem "json-schema", '< 5.1.1',                  require: false
+  gem "rspec-puppet-facts", '~> 4.0',            require: false if Gem::Requirement.create(['< 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "rspec-puppet-facts", '~> 5.0',            require: false if Gem::Requirement.create(['>= 3.0.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "dependency_checker", '~> 1.0.0',          require: false
   gem "parallel_tests", '= 3.12.1',              require: false
   gem "pry", '~> 0.10',                          require: false
   gem "simplecov-console", '~> 0.9',             require: false
-  gem "puppet-debugger", '~> 1.0',               require: false
-  gem "rubocop", '~> 1.50.0',                    require: false
-  gem "rubocop-performance", '= 1.16.0',         require: false
-  gem "rubocop-rspec", '= 2.19.0',               require: false
+  gem "puppet-debugger", '~> 1.6',               require: false
+  gem "rubocop", '~> 1.73.0',                    require: false
+  gem "rubocop-performance", '~> 1.24.0',        require: false
+  gem "rubocop-rspec", '~> 3.5.0',               require: false
+  gem "rubocop-rspec_rails", '~> 2.31.0',        require: false
+  gem "rubocop-factory_bot", '~> 2.27.0',        require: false
+  gem "rubocop-capybara", '~> 2.22.0',           require: false
   gem "rb-readline", '= 0.5.5',                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
-  gem "rexml", '>= 3.3.9',                       require: false
+  gem "bigdecimal", '< 3.2.2',                   require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "ruby-pwsh",                               require: false
 end
 group :development, :release_prep do
   gem "puppet-strings", '~> 4.0',         require: false
-  gem "puppetlabs_spec_helper", '~> 7.0', require: false
+  gem "puppetlabs_spec_helper", '~> 8.0', require: false
+  gem "puppet-blacksmith", '~> 7.0',      require: false
 end
 group :system_tests do
-  gem "puppet_litmus", '~> 1.0',   require: false, platforms: [:ruby, :x64_mingw]
+  gem "puppet_litmus", '~> 2.0',   require: false, platforms: [:ruby, :x64_mingw] if !ENV['PUPPET_FORGE_TOKEN'].to_s.empty?
+  gem "puppet_litmus", '~> 1.0',   require: false, platforms: [:ruby, :x64_mingw] if ENV['PUPPET_FORGE_TOKEN'].to_s.empty?
   gem "CFPropertyList", '< 3.0.7', require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "serverspec", '~> 2.41',     require: false
   gem "nokogiri",                  require: false, platforms: [:ruby, :mswin, :mingw, :x64_mingw]
 end
 
-puppet_version = ENV['PUPPET_GEM_VERSION']
-facter_version = ENV['FACTER_GEM_VERSION']
-hiera_version = ENV['HIERA_GEM_VERSION']
-
 gems = {}
+puppet_version = ENV.fetch('PUPPET_GEM_VERSION', nil)
+facter_version = ENV.fetch('FACTER_GEM_VERSION', nil)
+hiera_version = ENV.fetch('HIERA_GEM_VERSION', nil)
 
-gems['puppet'] = location_for(puppet_version)
+gems['puppet'] = location_for(puppet_version, nil, { source: gemsource_puppetcore })
+gems['facter'] = location_for(facter_version, nil, { source: gemsource_puppetcore })
+gems['hiera'] = location_for(hiera_version, nil, {}) if hiera_version
 
-# If facter or hiera versions have been specified via the environment
-# variables
-
-gems['facter'] = location_for(facter_version) if facter_version
-gems['hiera'] = location_for(hiera_version) if hiera_version
-
+# Generate the gem definitions
+print_gem_statement_for(gems) if ENV['DEBUG']
 gems.each do |gem_name, gem_params|
   gem gem_name, *gem_params
 end
@@ -69,12 +93,14 @@ end
 # Evaluate Gemfile.local and ~/.gemfile if they exist
 extra_gemfiles = [
   "#{__FILE__}.local",
-  File.join(Dir.home, '.gemfile'),
+  File.join(Dir.home, '.gemfile')
 ]
 
 extra_gemfiles.each do |gemfile|
-  if File.file?(gemfile) && File.readable?(gemfile)
-    eval(File.read(gemfile), binding)
-  end
+  next unless File.file?(gemfile) && File.readable?(gemfile)
+
+  # rubocop:disable Security/Eval
+  eval(File.read(gemfile), binding)
+  # rubocop:enable Security/Eval
 end
 # vim: syntax=ruby

--- a/Rakefile
+++ b/Rakefile
@@ -7,3 +7,12 @@ require 'puppet-syntax/tasks/puppet-syntax'
 require 'puppet-strings/tasks' if Gem.loaded_specs.key? 'puppet-strings'
 
 PuppetLint.configuration.send('disable_relative')
+PuppetLint.configuration.send('disable_80chars')
+PuppetLint.configuration.send('disable_140chars')
+PuppetLint.configuration.send('disable_class_inherits_from_params_class')
+PuppetLint.configuration.send('disable_autoloader_layout')
+PuppetLint.configuration.send('disable_documentation')
+PuppetLint.configuration.send('disable_single_quote_string_with_variables')
+PuppetLint.configuration.fail_on_warnings = true
+PuppetLint.configuration.ignore_paths = [".vendor/**/*.pp", ".bundle/**/*.pp", "pkg/**/*.pp", "spec/**/*.pp", "tests/**/*.pp", "types/**/*.pp", "vendor/**/*.pp"]
+

--- a/lib/puppet/provider/chocolateyconfig/windows.rb
+++ b/lib/puppet/provider/chocolateyconfig/windows.rb
@@ -18,7 +18,7 @@ Puppet::Type.type(:chocolateyconfig).provide(:windows) do
   commands chocolatey: PuppetX::Chocolatey::ChocolateyCommon.chocolatey_command
 
   def initialize(value = {})
-    super(value)
+    super
     @property_flush = {}
   end
 

--- a/lib/puppet/provider/chocolateyfeature/windows.rb
+++ b/lib/puppet/provider/chocolateyfeature/windows.rb
@@ -18,7 +18,7 @@ Puppet::Type.type(:chocolateyfeature).provide(:windows) do
   commands chocolatey: PuppetX::Chocolatey::ChocolateyCommon.chocolatey_command
 
   def initialize(value = {})
-    super(value)
+    super
     @property_flush = {}
   end
 

--- a/lib/puppet/provider/chocolateysource/windows.rb
+++ b/lib/puppet/provider/chocolateysource/windows.rb
@@ -22,7 +22,7 @@ Puppet::Type.type(:chocolateysource).provide(:windows) do
   commands chocolatey: PuppetX::Chocolatey::ChocolateyCommon.chocolatey_command
 
   def initialize(value = {})
-    super(value)
+    super
     @property_flush = {}
   end
 

--- a/lib/puppet/provider/package/chocolatey.rb
+++ b/lib/puppet/provider/package/chocolatey.rb
@@ -44,7 +44,7 @@ Puppet::Type.type(:package).provide(:chocolatey, parent: Puppet::Provider::Packa
   commands chocolatey: PuppetX::Chocolatey::ChocolateyCommon.chocolatey_command
 
   def initialize(value = {})
-    super(value)
+    super
   end
 
   def print
@@ -176,7 +176,7 @@ Puppet::Type.type(:package).provide(:chocolatey, parent: Puppet::Provider::Packa
     args << '-fy' if choco_exe
 
     choco_version = Gem::Version.new(PuppetX::Chocolatey::ChocolateyCommon.choco_version)
-    if (!choco_exe || choco_version >= Gem::Version.new(PuppetX::Chocolatey::ChocolateyCommon::MINIMUM_SUPPORTED_CHOCO_UNINSTALL_SOURCE)) && (@resource[:source])
+    if (!choco_exe || choco_version >= Gem::Version.new(PuppetX::Chocolatey::ChocolateyCommon::MINIMUM_SUPPORTED_CHOCO_UNINSTALL_SOURCE)) && @resource[:source]
       args << '--source' << @resource[:source]
     end
 

--- a/lib/puppet/type/chocolateysource.rb
+++ b/lib/puppet/type/chocolateysource.rb
@@ -211,6 +211,6 @@ Puppet::Type.newtype(:chocolateysource) do
 
   def set_sensitive_parameters(sensitive_parameters)
     parameter(:password)&.sensitive = true
-    super(sensitive_parameters)
+    super
   end
 end

--- a/metadata.json
+++ b/metadata.json
@@ -57,7 +57,7 @@
     "chocolatey for business",
     "chocolatey professional"
   ],
-  "pdk-version": "3.2.0",
+  "pdk-version": "3.5.0",
   "template-url": "https://github.com/puppetlabs/pdk-templates.git#main",
-  "template-ref": "tags/3.2.0.4-0-g5d17ec1"
+  "template-ref": "heads/main-0-g5c7dd04"
 }

--- a/metadata.json
+++ b/metadata.json
@@ -41,7 +41,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 7.0.0 < 9.0.0"
+      "version_requirement": ">= 8.0.0 < 9.0.0"
     }
   ],
   "description": "Chocolatey package provider for Puppet",

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,7 +26,7 @@ default_fact_files.each do |f|
 
   begin
     require 'deep_merge'
-    default_facts.deep_merge!(YAML.safe_load(File.read(f), permitted_classes: [], permitted_symbols: [], aliases: true))
+    default_facts.deep_merge!(YAML.safe_load_file(f, permitted_classes: [], permitted_symbols: [], aliases: true))
   rescue StandardError => e
     RSpec.configuration.reporter.message "WARNING: Unable to load #{f}: #{e}"
   end


### PR DESCRIPTION
A set of changes dedicated to implementing puppetcore into our modules. This update, amongst other changes, removes Puppet 7 support.

## Checklist
- [x] 🟢 Spec tests.
- [x] 🟢 Acceptance tests.
