### PR TITLE
Handle different output formats of "choco upgrade" command

### DIFF
--- a/lib/puppet/provider/package/chocolatey.rb
+++ b/lib/puppet/provider/package/chocolatey.rb
@@ -321,7 +321,10 @@ Puppet::Type.type(:package).provide(:chocolatey, parent: Puppet::Provider::Packa
 
           if compiled_choco?
             values = line.split('|')
-            package_ver = values[2]
+            # `choco upgrade --noop <pkg> -r` output:
+            #   name|current|pinned            -> no update available (3 fields)
+            #   name|current|available|pinned  -> update available (4 fields)
+            package_ver = (values.length >= 4) ? values[2] : values[1]
           else
             # Example: ( latest        : 2013.08.19.155043 )
             values = line.split(':').map(&:strip).delete_if(&:empty?)

--- a/lib/puppet/provider/package/chocolatey.rb
+++ b/lib/puppet/provider/package/chocolatey.rb
@@ -311,8 +311,9 @@ Puppet::Type.type(:package).provide(:chocolatey, parent: Puppet::Provider::Packa
   end
 
   def latest
-    package_ver = ''
+    package_ver = nil
     PuppetX::Chocolatey::ChocolateyCommon.set_env_chocolateyinstall
+    pkg_name = @resource[:name][%r{\A\S*}]
     begin
       execpipe(latestcmd) do |process|
         process.each_line do |line|
@@ -321,19 +322,39 @@ Puppet::Type.type(:package).provide(:chocolatey, parent: Puppet::Provider::Packa
 
           if compiled_choco?
             values = line.split('|')
+            # Skip lines that aren't a machine-readable data line for the
+            # requested package (warning/info output, SSL/cert error text,
+            # status lines, etc.).
+            next if values.length < 3
+            next unless values[0].casecmp(pkg_name).zero?
             # `choco upgrade --noop <pkg> -r` output:
             #   name|current|pinned            -> no update available (3 fields)
             #   name|current|available|pinned  -> update available (4 fields)
-            package_ver = (values.length >= 4) ? values[2] : values[1]
+            candidate = (values.length >= 4) ? values[2] : values[1]
           else
             # Example: ( latest        : 2013.08.19.155043 )
             values = line.split(':').map(&:strip).delete_if(&:empty?)
-            package_ver = values[1]
+            next unless values.length >= 2 && values[0].casecmp('latest').zero?
+            candidate = values[1]
           end
+
+          # Only accept a version-shaped string. Guards against e.g. the
+          # `pinned` flag ("false") landing in the version field on
+          # malformed/short output.
+          next unless candidate.is_a?(String) && candidate.match?(%r{\A\d+(\.\d+)*\z})
+
+          package_ver = candidate
         end
       end
     rescue Puppet::ExecutionFailure
       return nil
+    end
+
+    if package_ver.nil?
+      raise Puppet::Error,
+            "Could not determine the latest version of #{pkg_name}: " \
+            'no parseable version was returned (the source may be unreachable ' \
+            'or its certificate may have expired)'
     end
 
     package_ver

--- a/spec/unit/puppet/provider/package/chocolatey_spec.rb
+++ b/spec/unit/puppet/provider/package/chocolatey_spec.rb
@@ -655,6 +655,16 @@ describe Puppet::Type.type(:package).provider(:chocolatey) do
 
         # provider.latest
       end
+
+      it 'returns the available version when an update is available (4-field output)' do
+        allow(provider).to receive(:execpipe).and_yield(StringIO.new("treesizefree|4.6.3|4.8.1.1|false\n"))
+        expect(provider.latest).to eq('4.8.1.1')
+      end
+
+      it 'returns the current version when no update is available (3-field output)' do
+        allow(provider).to receive(:execpipe).and_yield(StringIO.new("putty.install|0.83.0|false\n"))
+        expect(provider.latest).to eq('0.83.0')
+      end
     end
 
     context 'with posh choco client' do

--- a/spec/unit/puppet/provider/package/chocolatey_spec.rb
+++ b/spec/unit/puppet/provider/package/chocolatey_spec.rb
@@ -665,6 +665,52 @@ describe Puppet::Type.type(:package).provider(:chocolatey) do
         allow(provider).to receive(:execpipe).and_yield(StringIO.new("putty.install|0.83.0|false\n"))
         expect(provider.latest).to eq('0.83.0')
       end
+
+      it 'returns the latest version when warning lines precede the data line' do
+        allow(provider).to receive(:execpipe).and_yield(StringIO.new(
+                                                         "Unable to connect to source 'https://example.com/v3/index.json'\n" \
+                                                         "chocolatey|18.1|19.0|false\n",
+                                                       ))
+        expect(provider.latest).to eq('19.0')
+      end
+
+      it 'raises Puppet::Error when the output contains no parseable data line' do
+        allow(provider).to receive(:execpipe).and_yield(StringIO.new(
+                                                         "Unable to connect to source 'https://example.com/v3/index.json'\n",
+                                                       ))
+        expect { provider.latest }.to raise_error(
+          Puppet::Error, %r{Could not determine the latest version of chocolatey},
+        )
+      end
+
+      it 'raises Puppet::Error when execpipe yields no output' do
+        allow(provider).to receive(:execpipe).and_yield(StringIO.new(''))
+        expect { provider.latest }.to raise_error(
+          Puppet::Error, %r{Could not determine the latest version of chocolatey},
+        )
+      end
+
+      it 'raises Puppet::Error when the version field is not a valid version (e.g. "false")' do
+        # Defensive: even if a future choco version produces a malformed line
+        # where the `pinned` flag lands in the version slot, latest must not
+        # propagate "false" as a version.
+        allow(provider).to receive(:execpipe).and_yield(StringIO.new("chocolatey|18.1|false|false\n"))
+        expect { provider.latest }.to raise_error(
+          Puppet::Error, %r{Could not determine the latest version of chocolatey},
+        )
+      end
+
+      it 'ignores data lines for a different package' do
+        allow(provider).to receive(:execpipe).and_yield(StringIO.new("someotherpkg|1.0|2.0|false\n"))
+        expect { provider.latest }.to raise_error(
+          Puppet::Error, %r{Could not determine the latest version of chocolatey},
+        )
+      end
+
+      it 'returns nil when the choco command exits non-zero (preserves existing rescue)' do
+        allow(provider).to receive(:execpipe).and_raise(Puppet::ExecutionFailure.new('boom'))
+        expect(provider.latest).to be_nil
+      end
     end
 
     context 'with posh choco client' do
@@ -683,6 +729,18 @@ describe Puppet::Type.type(:package).provider(:chocolatey) do
         # expect(provider).to receive(:chocolatey).with('version', 'chocolatey', '--source', 'c:\packages', '| findstr /R "latest" | findstr /V "latestCompare"')
 
         # provider.latest
+      end
+
+      it 'returns the latest version from well-formed posh output' do
+        allow(provider).to receive(:execpipe).and_yield(StringIO.new("latest        : 2013.08.19.155043\n"))
+        expect(provider.latest).to eq('2013.08.19.155043')
+      end
+
+      it 'raises Puppet::Error when posh output has no latest line' do
+        allow(provider).to receive(:execpipe).and_yield(StringIO.new("Unable to connect to source 'https://example.com/'\n"))
+        expect { provider.latest }.to raise_error(
+          Puppet::Error, %r{Could not determine the latest version of chocolatey},
+        )
       end
     end
   end


### PR DESCRIPTION
## Summary
The first commit fixes #382:

`choco upgrade --noop <pkg> -r` returns 3 pipe-delimited fields when no update is available (`name|current|pinned`) and 4 fields when one is (`name|current|available|pinned`). The provider's `latest` method always read `values[2]`, so for up-to-date packages it returned the pinned flag ("false") as the version, causing spurious noop changes.

The second commit fixes #380:

Previously `latest` could return an empty string, nil, or a non-version string (e.g. the `pinned` flag bleeding into the version slot) when the source produced output that didn't match the documented machine-readable format. Puppet's package type then saw `is != @latest`, called `provider.update`, and ran choco again against the broken source.

Both fixes modify the same code, so in order to avoid conflicting PRs, I've added both fixes to this PR.

## Additional Context
see #382 and #380

## Related Issues (if any)
https://github.com/puppetlabs/puppetlabs-chocolatey/issues/382
https://github.com/puppetlabs/puppetlabs-chocolatey/issues/380

## Checklist
- [X] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)