### PR TITLE
fix undefined constant issue

### DIFF
--- a/lib/puppet/provider/package/chocolatey.rb
+++ b/lib/puppet/provider/package/chocolatey.rb
@@ -33,10 +33,13 @@ Puppet::Type.type(:package).provide(:chocolatey, parent: Puppet::Provider::Packa
   has_feature :package_settings
   has_feature :version_ranges
 
-  if Puppet::Util::Platform.windows?
-    require 'puppet/util/package/version/range'
-    require 'puppet/util/package/version/gem'
-  end
+  require 'puppet/util/package/version/range'
+  require 'puppet/util/package/version/gem'
+  require 'puppet/util/package/version/debian'
+  GEM_VERSION       = Puppet::Util::Package::Version::Gem
+  GEM_VERSION_RANGE = Puppet::Util::Package::Version::Range
+  VersionRange      = Puppet::Util::Package::Version::Range
+  DebianVersion     = Puppet::Util::Package::Version::Debian
 
   require Pathname.new(__FILE__).dirname + '../../../' + 'puppet_x/chocolatey/chocolatey_common'
   include PuppetX::Chocolatey::ChocolateyCommon


### PR DESCRIPTION
## Summary
When installing a package at a specific version such as:
```puppet
package { "amd-ryzen-chipset":
  ensure => "2026.3.9"
}
```
I was getting the following error:
```
Error: Could not update: uninitialized constant VersionRange
Error: /Stage[main]/Profiles::Driver::Cpu::Ryzen/Package[amd-ryzen-chipset]/ensure: change from 'absent' to '2026.3.9' failed: Could not update: uninitialized constant VersionRange
```

## Additional Context
Claude led me to the provider Ruby being faulty when not using `:present` or `:absent`.

This PR ensures that the constants are always defined. I have tested this on my Windows 11 host running provider 8.0.3 (with my patch). I have not tested this on anything else. Making this in draft mode only in case anyone else stumbles across this same issue.

## Related Issues (if any)
Mention any related issues or pull requests.

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [x] Manually verified. (For example `puppet apply`)