### PR TITLE
(MODULES-11769) Cache prefetch results and match packages case-insensitively

### DIFF
--- a/lib/puppet/provider/package/chocolatey.rb
+++ b/lib/puppet/provider/package/chocolatey.rb
@@ -238,12 +238,31 @@ Puppet::Type.type(:package).provide(:chocolatey, parent: Puppet::Provider::Packa
   # It's a determination for one specific package, the package modeled by
   # the resource the method is called on.
   # Query provides the information for the single package identified by @Resource[:name].
+  #
+  # The provider's @property_hash is populated by self.prefetch, which calls
+  # self.instances (and therefore `choco list`) exactly once per run. Reading
+  # from it here avoids re-invoking `choco.exe list -lo -r` for every resource
+  # that was not matched during prefetch. An empty hash means the package is
+  # not installed (absent), so there is nothing to re-query. See MODULES-11769.
   def query
-    self.class.instances.each do |package|
-      return package.properties if @resource[:name][%r{\A\S*}].casecmp(package.name.downcase).zero?
-    end
+    @property_hash.empty? ? nil : @property_hash.dup
+  end
 
-    nil
+  # Override the inherited Puppet::Provider::Package.prefetch, which matches
+  # instances to resources with a case-SENSITIVE hash lookup (packages[name]).
+  # self.instances downcases every package name returned by `choco list`, so a
+  # mixed-case resource title such as 'DotNetFx' never matches 'dotnetfx' and
+  # falls through to query, re-running `choco list`. Matching case-insensitively
+  # here populates @property_hash during the single prefetch pass instead.
+  # See MODULES-11769.
+  def self.prefetch(resources)
+    packages = instances
+    return if packages.nil?
+
+    resources.each do |name, resource|
+      provider = packages.find { |pkg| name.casecmp(pkg.name).zero? }
+      resource.provider = provider if provider
+    end
   end
 
   def self.listcmd

--- a/spec/unit/puppet/provider/package/chocolatey_spec.rb
+++ b/spec/unit/puppet/provider/package/chocolatey_spec.rb
@@ -498,9 +498,15 @@ describe Puppet::Type.type(:package).provider(:chocolatey) do
   end
 
   context 'when updating' do
+    # MODULES-11769: update decides upgrade-vs-install from query, which now
+    # reads the prefetch-populated @property_hash rather than re-running
+    # `choco list`. A non-nil query means the package is present (upgrade); nil
+    # means absent (install). These specs stub query accordingly.
+    let(:present_package) { { ensure: '1.2.3', name: 'chocolatey', provider: :chocolatey } }
+
     context 'with compiled choco client' do
       before :each do
-        allow(provider).to receive_messages(on_hold?: false, use_package_exit_codes_feature_enabled?: false)
+        allow(provider).to receive_messages(on_hold?: false, use_package_exit_codes_feature_enabled?: false, query: present_package)
         allow(provider.class).to receive(:compiled_choco?).and_return(true)
         allow(PuppetX::Chocolatey::ChocolateyVersion).to receive(:version).and_return(first_compiled_choco_version)
         # unhold is called in installs on compiled choco
@@ -508,18 +514,12 @@ describe Puppet::Type.type(:package).provider(:chocolatey) do
       end
 
       it 'uses `chocolatey upgrade` when ensure latest and package present' do
-        allow(provider_class).to receive(:instances).and_return [provider_class.new(ensure: '1.2.3',
-                                                                                    name: 'chocolatey',
-                                                                                    provider: :chocolatey)]
         expect(provider).to receive(:chocolatey).with('upgrade', 'chocolatey', '-y', nil)
 
         provider.update
       end
 
       it 'calls with ignore package exit codes when = 0.9.10' do
-        allow(provider_class).to receive(:instances).and_return [provider_class.new(ensure: '1.2.3',
-                                                                                    name: 'chocolatey',
-                                                                                    provider: :chocolatey)]
         expect(PuppetX::Chocolatey::ChocolateyCommon).to receive(:choco_version).and_return(minimum_supported_choco_exit_codes).at_least(:once)
         resource[:ensure] = :present
         expect(provider).to receive(:chocolatey).with('upgrade', 'chocolatey', '-y', nil, '--ignore-package-exit-codes')
@@ -528,9 +528,6 @@ describe Puppet::Type.type(:package).provider(:chocolatey) do
       end
 
       it 'calls with ignore package exit codes when > 0.9.10' do
-        allow(provider_class).to receive(:instances).and_return [provider_class.new(ensure: '1.2.3',
-                                                                                    name: 'chocolatey',
-                                                                                    provider: :chocolatey)]
         expect(PuppetX::Chocolatey::ChocolateyCommon).to receive(:choco_version).and_return(choco_zero_ten_zero).at_least(:once)
         resource[:ensure] = :present
         expect(provider).to receive(:chocolatey).with('upgrade', 'chocolatey', '-y', nil, '--ignore-package-exit-codes')
@@ -539,9 +536,6 @@ describe Puppet::Type.type(:package).provider(:chocolatey) do
       end
 
       it 'calls with no-progress when = 0.10.4 and package_settings: verbose is not true' do
-        allow(provider_class).to receive(:instances).and_return [provider_class.new(ensure: '1.2.3',
-                                                                                    name: 'chocolatey',
-                                                                                    provider: :chocolatey)]
         expect(PuppetX::Chocolatey::ChocolateyCommon).to receive(:choco_version).and_return(minimum_supported_choco_no_progress).at_least(:once)
         resource[:ensure] = :present
         expect(provider).to receive(:chocolatey).with('upgrade', 'chocolatey', '-y', nil, '--ignore-package-exit-codes', '--no-progress')
@@ -550,9 +544,6 @@ describe Puppet::Type.type(:package).provider(:chocolatey) do
       end
 
       it 'calls with no-progress when > 0.10.4 and package_settings: verbose is not true' do
-        allow(provider_class).to receive(:instances).and_return [provider_class.new(ensure: '1.2.3',
-                                                                                    name: 'chocolatey',
-                                                                                    provider: :chocolatey)]
         expect(PuppetX::Chocolatey::ChocolateyCommon).to receive(:choco_version).and_return(choco_zero_eleven_zero).at_least(:once)
         resource[:ensure] = :present
         expect(provider).to receive(:chocolatey).with('upgrade', 'chocolatey', '-y', nil, '--ignore-package-exit-codes', '--no-progress')
@@ -561,9 +552,6 @@ describe Puppet::Type.type(:package).provider(:chocolatey) do
       end
 
       it 'does not call with no-progress when = 0.10.4 and package_settings: verbose is true' do
-        allow(provider_class).to receive(:instances).and_return [provider_class.new(ensure: '1.2.3',
-                                                                                    name: 'chocolatey',
-                                                                                    provider: :chocolatey)]
         expect(PuppetX::Chocolatey::ChocolateyCommon).to receive(:choco_version).and_return(minimum_supported_choco_no_progress).at_least(:once)
         resource[:package_settings] = { 'verbose' => true }
         resource[:ensure]           = :present
@@ -573,16 +561,13 @@ describe Puppet::Type.type(:package).provider(:chocolatey) do
       end
 
       it 'uses `chocolatey install` when ensure latest and package absent' do
-        allow(provider_class).to receive(:instances).and_return []
+        allow(provider).to receive(:query).and_return(nil)
         expect(provider).to receive(:chocolatey).with('install', 'chocolatey', '-y', nil)
 
         provider.update
       end
 
       it 'uses source if it is specified' do
-        expect(provider_class).to receive(:instances).and_return [provider_class.new(ensure: 'latest',
-                                                                                     name: 'chocolatey',
-                                                                                     provider: :chocolatey)]
         resource[:source] = 'c:\packages'
         expect(provider).to receive(:chocolatey).with('upgrade', 'chocolatey', '-y', '--source', 'c:\packages', nil)
 
@@ -590,9 +575,6 @@ describe Puppet::Type.type(:package).provider(:chocolatey) do
       end
 
       it 'calls the unhold method if the current package is on hold' do
-        expect(provider_class).to receive(:instances).and_return [provider_class.new(ensure: 'latest',
-                                                                                     name: 'chocolatey',
-                                                                                     provider: :chocolatey)]
         allow(provider).to receive(:on_hold?).and_return(true)
         expect(provider).to receive(:chocolatey).with('pin', 'remove', '-n', 'chocolatey')
         expect(provider).to receive(:chocolatey).with('upgrade', 'chocolatey', '-y', nil)
@@ -603,30 +585,25 @@ describe Puppet::Type.type(:package).provider(:chocolatey) do
 
     context 'with posh choco client' do
       before :each do
+        allow(provider).to receive(:query).and_return(present_package)
         allow(provider.class).to receive(:compiled_choco?).and_return(false)
         allow(PuppetX::Chocolatey::ChocolateyVersion).to receive(:version).and_return(last_posh_choco_version)
       end
 
       it 'uses `chocolatey update` when ensure latest and package present' do
-        allow(provider_class).to receive(:instances).and_return [provider_class.new(ensure: '1.2.3',
-                                                                                    name: 'chocolatey',
-                                                                                    provider: :chocolatey)]
         expect(provider).to receive(:chocolatey).with('update', 'chocolatey', nil)
 
         provider.update
       end
 
       it 'uses `chocolatey install` when ensure latest and package absent' do
-        allow(provider_class).to receive(:instances).and_return []
+        allow(provider).to receive(:query).and_return(nil)
         expect(provider).to receive(:chocolatey).with('install', 'chocolatey', nil)
 
         provider.update
       end
 
       it 'uses source if it is specified' do
-        expect(provider_class).to receive(:instances).and_return [provider_class.new(ensure: 'latest',
-                                                                                     name: 'chocolatey',
-                                                                                     provider: :chocolatey)]
         resource[:source] = 'c:\packages'
         expect(provider).to receive(:chocolatey).with('update', 'chocolatey', '--source', 'c:\packages', nil)
 

--- a/spec/unit/puppet/provider/package/chocolatey_spec.rb
+++ b/spec/unit/puppet/provider/package/chocolatey_spec.rb
@@ -697,20 +697,55 @@ describe Puppet::Type.type(:package).provider(:chocolatey) do
   end
 
   context 'query' do
-    it 'returns a hash when chocolatey and the package are present' do
-      expect(provider_class).to receive(:instances).and_return [provider_class.new(ensure: '1.2.5',
-                                                                                   name: 'chocolatey',
-                                                                                   provider: :chocolatey)]
+    it 'returns the prefetch-populated property_hash when the package is present' do
+      prov = provider_class.new(ensure: '1.2.5',
+                                name: 'chocolatey',
+                                provider: :chocolatey)
 
-      expect(provider.query).to eq(ensure: '1.2.5',
-                                   name: 'chocolatey',
-                                   provider: :chocolatey)
+      expect(prov.query).to eq(ensure: '1.2.5',
+                               name: 'chocolatey',
+                               provider: :chocolatey)
     end
 
-    it 'returns nil when the package is missing' do
-      expect(provider_class).to receive(:instances).and_return []
-
+    it 'returns nil when the package is missing (empty property_hash)' do
       expect(provider.query).to be_nil
+    end
+
+    # MODULES-11769: query must read the cached property_hash, never re-invoke
+    # self.instances (and therefore `choco list`) during catalog evaluation.
+    it 'does not re-invoke instances' do
+      expect(provider_class).not_to receive(:instances)
+
+      provider.query
+    end
+  end
+
+  # MODULES-11769: the overridden prefetch must match catalog resources to
+  # instances case-insensitively, since self.instances downcases every name.
+  context 'self.prefetch' do
+    it 'matches a mixed-case resource title to a lower-cased instance' do
+      pkg = provider_class.new(ensure: '1.2.5', name: 'git', provider: :chocolatey)
+      allow(provider_class).to receive(:instances).and_return [pkg]
+
+      mixed_case = Puppet::Type.type(:package).new(provider: :chocolatey, name: 'Git')
+      provider_class.prefetch('Git' => mixed_case)
+
+      expect(mixed_case.provider).to eq(pkg)
+    end
+
+    it 'calls instances (choco list) exactly once' do
+      expect(provider_class).to receive(:instances).once.and_return([])
+
+      provider_class.prefetch('chocolatey' => resource)
+    end
+
+    it 'leaves unmatched resources without a prefetched property_hash' do
+      allow(provider_class).to receive(:instances).and_return []
+
+      absent = Puppet::Type.type(:package).new(provider: :chocolatey, name: 'not-installed')
+      provider_class.prefetch('not-installed' => absent)
+
+      expect(absent.provider.query).to be_nil
     end
   end
 


### PR DESCRIPTION
## Summary

Fixes the redundant `choco.exe list -lo -r` invocations described in [MODULES-11769](https://perforce.atlassian.net/browse/MODULES-11769). On Windows each `choco.exe` call costs ~3-5s of .NET startup, so a node with mixed-case package titles or already-absent packages paid that cost many times per Puppet run.

## Root cause

The `chocolatey` package provider defeated Puppet's prefetch optimization in two ways:

1. **`query` never cached.** It called `self.class.instances` (→ `choco list`) on *every* invocation instead of reading the prefetch-populated `@property_hash`.
2. **Prefetch was case-sensitive.** The provider relied on the inherited `Puppet::Provider::Package.prefetch`, which does a case-sensitive `packages[name]` lookup — but `self.instances` downcases every package name. So `package { 'DotNetFx': }` never matched the `dotnetfx` instance, fell through to `query`, and re-ran `choco list`. `ensure => absent` packages that aren't installed hit the same fallthrough.

## Fix

- Override `self.prefetch` to match resources to instances **case-insensitively** (`casecmp`), populating `@property_hash` in the single prefetch pass.
- Rewrite `query` to return `@property_hash` (or `nil` when empty → absent), so no `choco.exe` runs during evaluation.

`self.instances` (and therefore `choco list`) now runs exactly once per run, matching the standard provider pattern used by `apt`/`yum`/`pip`.

## Tests

- `query` returns the cached `@property_hash` and no longer invokes `instances`.
- `self.prefetch` matches a mixed-case title to a lower-cased instance, calls `instances` exactly once, and leaves unmatched resources resolving to `nil` (absent) without re-querying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)