### PR TITLE
Update Chocolatey Community Repository and docs site URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ chocolateysource {'chocolatey':
 ~~~puppet
 chocolateysource {'chocolatey':
   ensure   => present,
-  location => 'https://chocolatey.org/api/v2',
+  location => 'https://community.chocolatey.org/api/v2/',
   priority => 1,
 }
 ~~~
@@ -476,7 +476,7 @@ package { 'notepadplusplus':
 package { 'notepadplusplus':
   ensure   => '6.7.5',
   provider => 'chocolatey',
-  source   => 'C:\local\folder\packages;https://chocolatey.org/api/v2/',
+  source   => 'C:\local\folder\packages;https://community.chocolatey.org/api/v2/',
 }
 ~~~
 
@@ -552,7 +552,7 @@ However, this information is not written to puppetdb or any other Puppet logs.
 
 It **is** written to the Chocolatey log on each machine unless you have C4B and use the `--package-parameters-sensitive` or `--install-arguments-sensitive` Chocolatey parameters, which will redact specified values from the Chocolatey log.
 
-For more information on these Chocolatey parameters, see the Chocolatey reference documentation on the [install command](https://chocolatey.org/docs/commands-install#options-and-switches) and the [upgrade command](https://chocolatey.org/docs/commands-upgrade#options-and-switches).
+For more information on these Chocolatey parameters, see the Chocolatey reference documentation on the [install command](https://docs.chocolatey.org/en-us/choco/commands/install/#options-and-switches) and the [upgrade command](https://docs.chocolatey.org/en-us/choco/commands/upgrade/#options-and-switches).
 
 If you need to include a secret in your `install_options`, do not run in debug mode in production and use C4B and the `--package-parameters-sensitive` or `--install-arguments-sensitive` Chocolatey parameter.
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -129,9 +129,9 @@ Data type: `String[1]`
 Specifies the source file for 7za.exe.
 Supports all sources supported by Puppet's file resource. You should use
 a 32bit binary for compatibility.
-Defaults to 'https://chocolatey.org/7za.exe'.
+Defaults to 'https://community.chocolatey.org/7za.exe'.
 
-Default value: `'https://chocolatey.org/7za.exe'`
+Default value: `'https://community.chocolatey.org/7za.exe'`
 
 ##### <a name="-chocolatey--choco_install_timeout_seconds"></a>`choco_install_timeout_seconds`
 
@@ -150,9 +150,9 @@ Data type: `Stdlib::Filesource`
 A url that will return
 `chocolatey.nupkg`. This must be a url, but not necessarily an OData feed.
 Any old url location will work. Defaults to
-`'https://chocolatey.org/api/v2/package/chocolatey/'`.
+`'https://community.chocolatey.org/api/v2/package/chocolatey/'`.
 
-Default value: `'https://chocolatey.org/api/v2/package/chocolatey/'`
+Default value: `'https://community.chocolatey.org/api/v2/package/chocolatey/'`
 
 ##### <a name="-chocolatey--enable_autouninstaller"></a>`enable_autouninstaller`
 
@@ -203,7 +203,7 @@ Configuration values provide settings for users
 to configure aspects of Chocolatey and the way it
 functions. Similar to features, except allow for user
 configured values. Requires 0.9.10+. Learn more about
-config at https://chocolatey.org/docs/commands-config
+config at https://docs.chocolatey.org/en-us/choco/commands/config/
 
 #### Properties
 
@@ -251,7 +251,7 @@ Allows managing features for Chocolatey. Features are
 configuration that act as feature flippers to turn on or
 off certain aspects of how Chocolatey works.
 Learn more about features at
-https://chocolatey.org/docs/commands-feature
+https://docs.chocolatey.org/en-us/choco/commands/feature/
 
 #### Properties
 
@@ -286,7 +286,7 @@ usually discover the appropriate provider for your platform.
 Allows managing sources for Chocolatey. A source can be a
 folder, a CIFS share, a NuGet Http OData feed, or a full
 Package Gallery. Learn more about sources at
-https://chocolatey.org/docs/how-to-host-feed
+https://docs.chocolatey.org/en-us/features/host-packages/
 
 #### Properties
 

--- a/lib/puppet/type/chocolateyconfig.rb
+++ b/lib/puppet/type/chocolateyconfig.rb
@@ -10,7 +10,7 @@ Puppet::Type.newtype(:chocolateyconfig) do
     to configure aspects of Chocolatey and the way it
     functions. Similar to features, except allow for user
     configured values. Requires 0.9.10+. Learn more about
-    config at https://chocolatey.org/docs/commands-config
+    config at https://docs.chocolatey.org/en-us/features/host-packages/
   DOC
 
   ensurable do

--- a/lib/puppet/type/chocolateyfeature.rb
+++ b/lib/puppet/type/chocolateyfeature.rb
@@ -9,7 +9,7 @@ Puppet::Type.newtype(:chocolateyfeature) do
     configuration that act as feature flippers to turn on or
     off certain aspects of how Chocolatey works.
     Learn more about features at
-    https://chocolatey.org/docs/commands-feature
+    https://docs.chocolatey.org/en-us/choco/commands/feature/
 
   EOT
 

--- a/lib/puppet/type/chocolateysource.rb
+++ b/lib/puppet/type/chocolateysource.rb
@@ -8,7 +8,7 @@ Puppet::Type.newtype(:chocolateysource) do
     Allows managing sources for Chocolatey. A source can be a
     folder, a CIFS share, a NuGet Http OData feed, or a full
     Package Gallery. Learn more about sources at
-    https://chocolatey.org/docs/how-to-host-feed
+    https://docs.chocolatey.org/en-us/features/host-packages/
 
   EOT
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,7 +47,7 @@
 # @param [String] seven_zip_download_url Specifies the source file for 7za.exe.
 #   Supports all sources supported by Puppet's file resource. You should use
 #   a 32bit binary for compatibility.
-#   Defaults to 'https://chocolatey.org/7za.exe'.
+#   Defaults to 'https://community.chocolatey.org/7za.exe'.
 #
 # @param [Integer] choco_install_timeout_seconds How long in seconds should
 #   be allowed for the install of Chocolatey (including .NET Framework 4 if
@@ -56,7 +56,7 @@
 # @param [String] chocolatey_download_url A url that will return
 #   `chocolatey.nupkg`. This must be a url, but not necessarily an OData feed.
 #   Any old url location will work. Defaults to
-#   `'https://chocolatey.org/api/v2/package/chocolatey/'`.
+#   `'https://community.chocolatey.org/api/v2/package/chocolatey/'`.
 #
 # @param [Boolean] enable_autouninstaller [Deprecated] - Should auto
 #   uninstaller be turned on? Auto uninstaller is what allows Chocolatey to
@@ -76,9 +76,9 @@
 class chocolatey (
   Stdlib::Windowspath $choco_install_location = $facts['choco_install_path'],
   Boolean $use_7zip                           = false,
-  String[1] $seven_zip_download_url           = 'https://chocolatey.org/7za.exe',
+  String[1] $seven_zip_download_url           = 'https://community.chocolatey.org/7za.exe',
   Integer $choco_install_timeout_seconds      = 1500,
-  Stdlib::Filesource $chocolatey_download_url = 'https://chocolatey.org/api/v2/package/chocolatey/',
+  Stdlib::Filesource $chocolatey_download_url = 'https://community.chocolatey.org/api/v2/package/chocolatey/',
   Boolean $enable_autouninstaller             = true,
   Boolean $log_output                         = false,
   String[1] $chocolatey_version               = $facts['chocolateyversion'],

--- a/spec/acceptance/sources_spec.rb
+++ b/spec/acceptance/sources_spec.rb
@@ -18,7 +18,7 @@ describe 'chocolateysource resource' do
       <<-MANIFEST
         chocolateysource {'chocolatey':
           ensure             => present,
-          location           => 'https://chocolatey.org/api/v2',
+          location           => 'https://community.chocolatey.org/api/v2/',
           priority           => 2,
           user               => 'bob',
           password           => 'yes',
@@ -35,7 +35,7 @@ describe 'chocolateysource resource' do
         expect(result.stdout).to match(%r{Debug: Executing: '\[redacted\]'})
       end
       run_shell(config_content_command, acceptable_exit_codes: [0]) do |result|
-        expect(get_xml_value("//sources/source[@id='chocolatey']/@value", result.stdout).to_s).to match(%r{https://chocolatey.org/api/v2})
+        expect(get_xml_value("//sources/source[@id='chocolatey']/@value", result.stdout).to_s).to match(%r{https://community.chocolatey.org/api/v2/})
         expect(get_xml_value("//sources/source[@id='chocolatey']/@priority", result.stdout).to_s).to match(%r{2})
         expect(get_xml_value("//sources/source[@id='chocolatey']/@user", result.stdout).to_s).to match(%r{bob})
         expect(get_xml_value("//sources/source[@id='chocolatey']/@password", result.stdout).to_s).to match(%r{.+})
@@ -54,7 +54,7 @@ describe 'chocolateysource resource' do
       <<-MANIFEST
         chocolateysource {'chocolatey':
           ensure             => present,
-          location           => 'https://chocolatey.org/api/v2',
+          location           => 'https://community.chocolatey.org/api/v2/',
           priority           => 2,
           user               => 'bob',
           password           => 'yes',
@@ -106,7 +106,7 @@ describe 'chocolateysource resource' do
       <<-MANIFEST
         chocolateysource {'chocolatey':
           ensure             => present,
-          location           => 'https://chocolatey.org/api/v2',
+          location           => 'https://community.chocolatey.org/api/v2/',
           priority           => 2,
           user               => 'bob',
           password           => 'yes',
@@ -121,7 +121,7 @@ describe 'chocolateysource resource' do
       <<-MANIFEST
         chocolateysource {'chocolatey':
           ensure   => present,
-          location => 'https://chocolatey.org/api/v2',
+          location => 'https://community.chocolatey.org/api/v2/',
         }
       MANIFEST
     end
@@ -129,7 +129,7 @@ describe 'chocolateysource resource' do
     it 'applies manifest, sets config' do
       idempotent_apply(pp_chocolateysource)
       run_shell(config_content_command) do |result|
-        expect(get_xml_value("//sources/source[@id='chocolatey']/@value", result.stdout).to_s).to match(%r{https://chocolatey.org/api/v2})
+        expect(get_xml_value("//sources/source[@id='chocolatey']/@value", result.stdout).to_s).to match(%r{https://community.chocolatey.org/api/v2/})
         expect(get_xml_value("//sources/source[@id='chocolatey']/@priority", result.stdout).to_s).to match(%r{2})
         expect(get_xml_value("//sources/source[@id='chocolatey']/@user", result.stdout).to_s).to match(%r{bob})
         expect(get_xml_value("//sources/source[@id='chocolatey']/@password", result.stdout).to_s).to match(%r{.+})
@@ -143,7 +143,7 @@ describe 'chocolateysource resource' do
     it 'applies manifest, unsets config attributes' do
       idempotent_apply(pp_chocolateysource_remove)
       run_shell(config_content_command) do |result|
-        expect(get_xml_value("//sources/source[@id='chocolatey']/@value", result.stdout).to_s).to match(%r{https://chocolatey.org/api/v2})
+        expect(get_xml_value("//sources/source[@id='chocolatey']/@value", result.stdout).to_s).to match(%r{https://community.chocolatey.org/api/v2/})
         expect(get_xml_value("//sources/source[@id='chocolatey']/@priority", result.stdout).to_s).to match(%r{0})
         expect(get_xml_value("//sources/source[@id='chocolatey']/@user", result.stdout).to_s).to match(%r{})
         expect(get_xml_value("//sources/source[@id='chocolatey']/@password", result.stdout).to_s).to match(%r{})
@@ -237,7 +237,7 @@ describe 'chocolateysource resource' do
         <<-MANIFEST
           chocolateysource {'chocolatey':
             ensure   => present,
-            location => 'https://chocolatey.org/api/v2',
+            location => 'https://community.chocolatey.org/api/v2/',
             password => 'test',
           }
         MANIFEST
@@ -256,7 +256,7 @@ describe 'chocolateysource resource' do
         <<-MANIFEST
           chocolateysource {'chocolatey':
             ensure   => present,
-            location => 'https://chocolatey.org/api/v2',
+            location => 'https://community.chocolatey.org/api/v2/',
             user => 'tim',
           }
         MANIFEST

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -40,7 +40,7 @@ describe 'chocolatey' do
   end
 
   context 'chocolatey_download_url =>' do
-    ['https://chocolatey.org/api/v2/package/chocolatey/', 'http://location', 'file:///c:/somwhere/chocolatey.nupkg', '\\\\ciflocation\\share'].each do |param_value|
+    ['https://community.chocolatey.org/api/v2/package/chocolatey/', 'http://location', 'file:///c:/somwhere/chocolatey.nupkg', '\\\\ciflocation\\share'].each do |param_value|
       context param_value.to_s do
         let(:params) do
           {

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -41,7 +41,7 @@ describe 'chocolatey' do
       context 'seven_zip_download_url default' do
         let(:params) { { use_7zip: true } }
 
-        it { is_expected.to contain_file('C:\Temp\7za.exe').with_source('https://chocolatey.org/7za.exe') }
+        it { is_expected.to contain_file('C:\Temp\7za.exe').with_source('https://community.chocolatey.org/7za.exe') }
       end
 
       context "seven_zip_download_url => 'https://packages.organization.net/7za.exe'" do

--- a/spec/unit/puppet/provider/chocolateyconfig/windows_spec.rb
+++ b/spec/unit/puppet/provider/chocolateyconfig/windows_spec.rb
@@ -30,7 +30,7 @@ describe Puppet::Type.type(:chocolateyconfig).provider(:windows) do
         </config>
         <sources>
           <source id="local" value="c:\packages" disabled="true" user="rob" password="bogus/encrypted+value=" priority="0" />
-          <source id="chocolatey" value="https://chocolatey.org/api/v2/" disabled="false" priority="0" />
+          <source id="chocolatey" value="https://community.chocolatey.org/api/v2/" disabled="false" priority="0" />
           <source id="chocolatey.licensed" value="https://licensedpackages.chocolatey.org/api/v2/" disabled="false" user="customer" password="bogus/encrypted+value=" priority="10" />
         </sources>
         <features>

--- a/spec/unit/puppet/provider/chocolateyfeature/windows_spec.rb
+++ b/spec/unit/puppet/provider/chocolateyfeature/windows_spec.rb
@@ -31,7 +31,7 @@ describe provider do
         </config>
         <sources>
           <source id="local" value="c:\packages" disabled="true" user="rob" password="bogus\/encrypted+value=" priority="0" />
-          <source id="chocolatey" value="https://chocolatey.org/api/v2/" disabled="false" priority="0" />
+          <source id="chocolatey" value="https://community.chocolatey.org/api/v2/" disabled="false" priority="0" />
           <source id="chocolatey.licensed" value="https://licensedpackages.chocolatey.org/api/v2/" disabled="false" user="customer" password="bogus/encrypted+value=" priority="10" />
         </sources>
         <features>

--- a/spec/unit/puppet/provider/chocolateysource/windows_spec.rb
+++ b/spec/unit/puppet/provider/chocolateysource/windows_spec.rb
@@ -32,7 +32,7 @@ describe provider do
         </config>
         <sources>
           <source id="local" value="c:\packages" disabled="true" user="rob" password="bogus/encrypted+value=" priority="0" />
-          <source id="chocolatey" value="https://chocolatey.org/api/v2/" disabled="false" priority="0" />
+          <source id="chocolatey" value="https://community.chocolatey.org/api/v2/" disabled="false" priority="0" />
           <source id="chocolatey.licensed" value="https://licensedpackages.chocolatey.org/api/v2/" disabled="false" user="customer" password="bogus/encrypted+value=" priority="10" />
         </sources>
         <features>

--- a/spec/unit/puppet/provider/package/chocolatey_spec.rb
+++ b/spec/unit/puppet/provider/package/chocolatey_spec.rb
@@ -37,7 +37,7 @@ describe Puppet::Type.type(:package).provider(:chocolatey) do
         </config>
         <sources>
           <source id="local" value="c:\packages" disabled="true" user="rob" password="bogus/encrypted+value=" priority="0" />
-          <source id="chocolatey" value="https://chocolatey.org/api/v2/" disabled="false" priority="0" />
+          <source id="chocolatey" value="https://community.chocolatey.org/api/v2/" disabled="false" priority="0" />
           <source id="chocolatey.licensed" value="https://licensedpackages.chocolatey.org/api/v2/" disabled="false" user="customer" password="bogus/encrypted+value=" priority="10" />
         </sources>
         <features>


### PR DESCRIPTION
## Summary

The Chocolatey Community Repository and docs site were separate onto their own subdomains a number of years ago.

The default source setup with a native install of Chocolatey CLI points to `https://community.chocolatey.org/api/v2/`

This PR updates relevant URLs to the modern equivalents and eliminates unnecessary redirects.

## Additional Context

N/A

## Related Issues (if any)

N/A

## Checklist
- [ ] 🟢 Spec tests.
- [ ] 🟢 Acceptance tests.
- [ ] Manually verified. (For example `puppet apply`)